### PR TITLE
SWDEV-536038 - Include <thread> header

### DIFF
--- a/lib/source/HIPTimer.cpp
+++ b/lib/source/HIPTimer.cpp
@@ -31,6 +31,7 @@
 #include <rocRoller/Utilities/HIPTimer.hpp>
 #include <rocRoller/Utilities/HipUtils.hpp>
 #include <rocRoller/Utilities/Timer.hpp>
+#include <thread>
 
 namespace rocRoller
 {

--- a/test/catch/SettingsTest.cpp
+++ b/test/catch/SettingsTest.cpp
@@ -31,6 +31,7 @@
 #include "SimpleTest.hpp"
 #include "common/SourceMatcher.hpp"
 #include <rocRoller/Utilities/Settings_fwd.hpp>
+#include <thread>
 
 using namespace rocRoller;
 using namespace Catch::Matchers;


### PR DESCRIPTION
# PR overview

Work item: SWDEV-536040

What were the changes?
Added include directive <thread> for 
lib/include/rocRoller/Utilities/Settings.hpp
lib/include/rocRoller/Utilities/Timer.hpp

Why were the changes made?
Unused headers removed in ROCM7.0.

How was the outcome achieved?
Adding this include removes build failure.

## Testing

Describe how you have tested your code here.
Compiled with latest staging clr c2f6c980 on 16151 latest mainline docker.

# Commit message

Include <thread> as unused headers removed in ROCM7.0.

