### PR TITLE
declspec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,14 +137,16 @@ set_property(CACHE YAML_BACKEND PROPERTY STRINGS YAML_CPP LLVM)
 # For paths given when reporting errors
 add_compile_options(-fmacro-prefix-map=${PROJECT_SOURCE_DIR}=.)
 
+set(EXTRA_LINK_OPTIONS "-Wl,--exclude-libs,ALL")
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(COROUTINES_COMPILE_OPTION)
     set(EXTRA_COMPILE_OPTIONS)
-    set(EXTRA_LINK_OPTIONS -fuse-ld=lld -frtti)
+    list(PREPEND EXTRA_LINK_OPTIONS -fuse-ld=lld -frtti)
 else()
     set(COROUTINES_COMPILE_OPTION -fcoroutines)
     set(EXTRA_COMPILE_OPTIONS)
-    set(EXTRA_LINK_OPTIONS -frtti)
+    list(PREPEND EXTRA_LINK_OPTIONS -frtti)
 endif()
 
 if(ROCROLLER_ENABLE_TIMERS)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -265,6 +265,8 @@ set_target_properties(
     rocroller PROPERTIES
         VERSION ${ROCROLLER_VERSION}
         SOVERSION ${ROCROLLER_SOVERSION}
+        VISIBILITY_INLINES_HIDDEN ON
+        CXX_VISIBILITY_PRESET hidden
 )
 
 target_link_libraries(rocroller

--- a/lib/include/rocRoller/Assemblers/Assembler.hpp
+++ b/lib/include/rocRoller/Assemblers/Assembler.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -35,9 +37,9 @@
 
 namespace rocRoller
 {
-    std::ostream& operator<<(std::ostream&, AssemblerType);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, AssemblerType);
 
-    class Assembler
+    class ROCROLLER_DECLSPEC Assembler
     {
     public:
         using Argument = AssemblerType;

--- a/lib/include/rocRoller/Assemblers/Assembler_fwd.hpp
+++ b/lib/include/rocRoller/Assemblers/Assembler_fwd.hpp
@@ -26,12 +26,14 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 #include <string>
 
 namespace rocRoller
 {
-    class Assembler;
+    class ROCROLLER_DECLSPEC Assembler;
     using AssemblerPtr = std::shared_ptr<Assembler>;
 
     enum class AssemblerType : int
@@ -41,5 +43,5 @@ namespace rocRoller
         Count
     };
 
-    std::string toString(AssemblerType t);
+    ROCROLLER_DECLSPEC std::string toString(AssemblerType t);
 }

--- a/lib/include/rocRoller/Assemblers/InProcessAssembler.hpp
+++ b/lib/include/rocRoller/Assemblers/InProcessAssembler.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Assemblers/Assembler.hpp>
 #include <rocRoller/GPUArchitecture/GPUArchitectureTarget.hpp>
 
@@ -33,7 +35,7 @@
 
 namespace rocRoller
 {
-    class InProcessAssembler : public Assembler
+    class ROCROLLER_DECLSPEC InProcessAssembler : public Assembler
     {
     public:
         InProcessAssembler();

--- a/lib/include/rocRoller/Assemblers/SubprocessAssembler.hpp
+++ b/lib/include/rocRoller/Assemblers/SubprocessAssembler.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Assemblers/Assembler.hpp>
 #include <rocRoller/GPUArchitecture/GPUArchitectureTarget.hpp>
 
@@ -34,7 +36,7 @@
 
 namespace rocRoller
 {
-    class SubprocessAssembler : public Assembler
+    class ROCROLLER_DECLSPEC SubprocessAssembler : public Assembler
     {
     public:
         SubprocessAssembler();

--- a/lib/include/rocRoller/AssemblyKernel.hpp
+++ b/lib/include/rocRoller/AssemblyKernel.hpp
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -43,7 +45,7 @@
 
 namespace rocRoller
 {
-    class AssemblyKernel
+    class ROCROLLER_DECLSPEC AssemblyKernel
     {
     public:
         AssemblyKernel(ContextPtr context, std::string const& kernelName);
@@ -231,7 +233,7 @@ namespace rocRoller
         CommandPtr                  m_command;
     };
 
-    struct AssemblyKernels
+    struct ROCROLLER_DECLSPEC AssemblyKernels
     {
         constexpr std::array<int, 2> hsa_version()
         {

--- a/lib/include/rocRoller/AssemblyKernelArgument.hpp
+++ b/lib/include/rocRoller/AssemblyKernelArgument.hpp
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 
 #include <rocRoller/Expression.hpp>
@@ -36,7 +38,7 @@
 namespace rocRoller
 {
 
-    struct AssemblyKernelArgument
+    struct ROCROLLER_DECLSPEC AssemblyKernelArgument
     {
         std::string   name;
         VariableType  variableType;
@@ -52,5 +54,6 @@ namespace rocRoller
         std::string toString() const;
     };
 
-    std::ostream& operator<<(std::ostream& stream, AssemblyKernelArgument const& arg);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&                 stream,
+                                                AssemblyKernelArgument const& arg);
 }

--- a/lib/include/rocRoller/AssemblyKernelArgument_fwd.hpp
+++ b/lib/include/rocRoller/AssemblyKernelArgument_fwd.hpp
@@ -29,11 +29,13 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 namespace rocRoller
 {
-    struct AssemblyKernelArgument;
+    struct ROCROLLER_DECLSPEC AssemblyKernelArgument;
 
     using AssemblyKernelArgumentPtr = std::shared_ptr<AssemblyKernelArgument>;
 }

--- a/lib/include/rocRoller/AssemblyKernel_fwd.hpp
+++ b/lib/include/rocRoller/AssemblyKernel_fwd.hpp
@@ -29,10 +29,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 namespace rocRoller
 {
-    class AssemblyKernel;
+    class ROCROLLER_DECLSPEC AssemblyKernel;
     using AssemblyKernelPtr = std::shared_ptr<AssemblyKernel>;
 }

--- a/lib/include/rocRoller/AssertOpKinds.hpp
+++ b/lib/include/rocRoller/AssertOpKinds.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 
 #include <rocRoller/AssertOpKinds_fwd.hpp>
@@ -33,7 +35,7 @@
 namespace rocRoller
 {
 
-    std::string   toString(const AssertOpKind& assertOpKind);
-    std::ostream& operator<<(std::ostream&, AssertOpKind const);
+    ROCROLLER_DECLSPEC std::string toString(AssertOpKind const& assertOpKind);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, AssertOpKind const);
 
 }

--- a/lib/include/rocRoller/CodeGen/Annotate.hpp
+++ b/lib/include/rocRoller/CodeGen/Annotate.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Instruction.hpp>
 #include <rocRoller/Utilities/Generator.hpp>
 
@@ -40,7 +42,7 @@ namespace rocRoller
      * This will add the comment "foo" to each instruction that's part of
      * generating `expr`.
      */
-    class AddComment
+    class ROCROLLER_DECLSPEC AddComment
     {
     public:
         AddComment(std::string comment)
@@ -63,7 +65,7 @@ namespace rocRoller
      * Really intended for use only from LowerFromKernelGraph, so that every
      * instruction is annotated with the control op that it came from.
      */
-    class AddControlOp
+    class ROCROLLER_DECLSPEC AddControlOp
     {
     public:
         AddControlOp(int op)

--- a/lib/include/rocRoller/CodeGen/ArgumentLoader.hpp
+++ b/lib/include/rocRoller/CodeGen/ArgumentLoader.hpp
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 #include <unordered_map>
 
@@ -40,7 +42,7 @@
 
 namespace rocRollerTest
 {
-    class ArgumentLoaderTest_loadArgExtra_Test;
+    class ROCROLLER_DECLSPEC ArgumentLoaderTest_loadArgExtra_Test;
 }
 
 namespace rocRoller
@@ -57,7 +59,7 @@ namespace rocRoller
      * instructions as well as possibly more synchronization.
      *
      */
-    class ArgumentLoader
+    class ROCROLLER_DECLSPEC ArgumentLoader
     {
     public:
         ArgumentLoader(AssemblyKernelPtr kernel);

--- a/lib/include/rocRoller/CodeGen/ArgumentLoader_fwd.hpp
+++ b/lib/include/rocRoller/CodeGen/ArgumentLoader_fwd.hpp
@@ -29,8 +29,10 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
-    class ArgumentLoader;
+    class ROCROLLER_DECLSPEC ArgumentLoader;
 
 }

--- a/lib/include/rocRoller/CodeGen/Arithmetic/Add.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/Add.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,15 +35,15 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::Add>>
-        GetGenerator<Expression::Add>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::Add>>
+                       GetGenerator<Expression::Add>(Register::ValuePtr dst,
                                       Register::ValuePtr lhs,
                                       Register::ValuePtr rhs,
                                       Expression::Add const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class AddGenerator : public BinaryArithmeticGenerator<Expression::Add>
+    class ROCROLLER_DECLSPEC AddGenerator : public BinaryArithmeticGenerator<Expression::Add>
     {
     public:
         AddGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/AddShiftL.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/AddShiftL.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,15 +35,16 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<TernaryArithmeticGenerator<Expression::AddShiftL>>
-        GetGenerator<Expression::AddShiftL>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<TernaryArithmeticGenerator<Expression::AddShiftL>>
+                       GetGenerator<Expression::AddShiftL>(Register::ValuePtr dst,
                                             Register::ValuePtr lhs,
                                             Register::ValuePtr rhs,
                                             Register::ValuePtr shiftAmount,
                                             Expression::AddShiftL const&);
 
     // Generator for all register types and datatypes.
-    class AddShiftLGenerator : public TernaryArithmeticGenerator<Expression::AddShiftL>
+    class ROCROLLER_DECLSPEC AddShiftLGenerator
+        : public TernaryArithmeticGenerator<Expression::AddShiftL>
     {
     public:
         AddShiftLGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Instruction.hpp>
 #include <rocRoller/Utilities/Error.hpp>
 #include <rocRoller/Utilities/Generator.hpp>
@@ -34,7 +36,7 @@ namespace rocRoller
 {
     /// Base Arithmetic Generator class. All Arithmetic generators should be derived
     /// from this class.
-    class ArithmeticGenerator
+    class ROCROLLER_DECLSPEC ArithmeticGenerator
     {
     public:
         ArithmeticGenerator(ContextPtr context)
@@ -101,7 +103,7 @@ namespace rocRoller
     // Unary Arithmetic Generator. Most unary generators should be derived from
     // this class.
     template <Expression::CUnary Operation>
-    class UnaryArithmeticGenerator : public ArithmeticGenerator
+    class ROCROLLER_DECLSPEC UnaryArithmeticGenerator : public ArithmeticGenerator
     {
     public:
         UnaryArithmeticGenerator(ContextPtr context)
@@ -129,7 +131,7 @@ namespace rocRoller
     // Binary Arithmetic Generator. Most binary generators should be derived from
     // this class.
     template <Expression::CBinary Operation>
-    class BinaryArithmeticGenerator : public ArithmeticGenerator
+    class ROCROLLER_DECLSPEC BinaryArithmeticGenerator : public ArithmeticGenerator
     {
     public:
         BinaryArithmeticGenerator(ContextPtr context)
@@ -160,7 +162,7 @@ namespace rocRoller
     // Ternary Arithmetic Generator. Most ternary generators should be derived from
     // this class.
     template <Expression::CTernary Operation>
-    class TernaryArithmeticGenerator : public ArithmeticGenerator
+    class ROCROLLER_DECLSPEC TernaryArithmeticGenerator : public ArithmeticGenerator
     {
     public:
         TernaryArithmeticGenerator(ContextPtr context)
@@ -192,7 +194,7 @@ namespace rocRoller
     // TernaryMixed Arithmetic Generator. Only Ternary generators that can support mixed
     // airthmetic should be derived from this class.
     template <Expression::CTernaryMixed Operation>
-    class TernaryMixedArithmeticGenerator : public ArithmeticGenerator
+    class ROCROLLER_DECLSPEC TernaryMixedArithmeticGenerator : public ArithmeticGenerator
     {
     public:
         TernaryMixedArithmeticGenerator(ContextPtr context)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/ArithmeticShiftR.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/ArithmeticShiftR.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,14 +35,15 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::ArithmeticShiftR>>
-        GetGenerator<Expression::ArithmeticShiftR>(Register::ValuePtr                  dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::ArithmeticShiftR>>
+                       GetGenerator<Expression::ArithmeticShiftR>(Register::ValuePtr                  dst,
                                                    Register::ValuePtr                  lhs,
                                                    Register::ValuePtr                  rhs,
                                                    Expression::ArithmeticShiftR const& expr);
 
     // Generator for all register types and datatypes.
-    class ArithmeticShiftRGenerator : public BinaryArithmeticGenerator<Expression::ArithmeticShiftR>
+    class ROCROLLER_DECLSPEC ArithmeticShiftRGenerator
+        : public BinaryArithmeticGenerator<Expression::ArithmeticShiftR>
     {
     public:
         ArithmeticShiftRGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/BitFieldExtract.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/BitFieldExtract.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,11 +35,14 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<UnaryArithmeticGenerator<Expression::BitFieldExtract>> GetGenerator(
-        Register::ValuePtr dst, Register::ValuePtr arg, Expression::BitFieldExtract const& expr);
+    ROCROLLER_DECLSPEC std::shared_ptr<UnaryArithmeticGenerator<Expression::BitFieldExtract>>
+                       GetGenerator(Register::ValuePtr                 dst,
+                                    Register::ValuePtr                 arg,
+                                    Expression::BitFieldExtract const& expr);
 
     template <DataType DATATYPE>
-    class BitFieldExtractGenerator : public UnaryArithmeticGenerator<Expression::BitFieldExtract>
+    class ROCROLLER_DECLSPEC BitFieldExtractGenerator
+        : public UnaryArithmeticGenerator<Expression::BitFieldExtract>
     {
     public:
         BitFieldExtractGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/BitwiseAnd.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/BitwiseAnd.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,14 +35,15 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::BitwiseAnd>>
-        GetGenerator<Expression::BitwiseAnd>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::BitwiseAnd>>
+                       GetGenerator<Expression::BitwiseAnd>(Register::ValuePtr dst,
                                              Register::ValuePtr lhs,
                                              Register::ValuePtr rhs,
                                              Expression::BitwiseAnd const&);
 
     // Generator for all register types and datatypes.
-    class BitwiseAndGenerator : public BinaryArithmeticGenerator<Expression::BitwiseAnd>
+    class ROCROLLER_DECLSPEC BitwiseAndGenerator
+        : public BinaryArithmeticGenerator<Expression::BitwiseAnd>
     {
     public:
         BitwiseAndGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/BitwiseNegate.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/BitwiseNegate.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,13 +35,14 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<UnaryArithmeticGenerator<Expression::BitwiseNegate>>
-        GetGenerator<Expression::BitwiseNegate>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<UnaryArithmeticGenerator<Expression::BitwiseNegate>>
+                       GetGenerator<Expression::BitwiseNegate>(Register::ValuePtr dst,
                                                 Register::ValuePtr arg,
                                                 Expression::BitwiseNegate const&);
 
     // Templated Generator class based on the return type.
-    class BitwiseNegateGenerator : public UnaryArithmeticGenerator<Expression::BitwiseNegate>
+    class ROCROLLER_DECLSPEC BitwiseNegateGenerator
+        : public UnaryArithmeticGenerator<Expression::BitwiseNegate>
     {
     public:
         BitwiseNegateGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/BitwiseOr.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/BitwiseOr.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,14 +35,15 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::BitwiseOr>>
-        GetGenerator<Expression::BitwiseOr>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::BitwiseOr>>
+                       GetGenerator<Expression::BitwiseOr>(Register::ValuePtr dst,
                                             Register::ValuePtr lhs,
                                             Register::ValuePtr rhs,
                                             Expression::BitwiseOr const&);
 
     // Generator for all register types and datatypes.
-    class BitwiseOrGenerator : public BinaryArithmeticGenerator<Expression::BitwiseOr>
+    class ROCROLLER_DECLSPEC BitwiseOrGenerator
+        : public BinaryArithmeticGenerator<Expression::BitwiseOr>
     {
     public:
         BitwiseOrGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/BitwiseXor.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/BitwiseXor.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,14 +35,15 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::BitwiseXor>>
-        GetGenerator<Expression::BitwiseXor>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::BitwiseXor>>
+                       GetGenerator<Expression::BitwiseXor>(Register::ValuePtr dst,
                                              Register::ValuePtr lhs,
                                              Register::ValuePtr rhs,
                                              Expression::BitwiseXor const&);
 
     // Generator for all register types and datatypes.
-    class BitwiseXorGenerator : public BinaryArithmeticGenerator<Expression::BitwiseXor>
+    class ROCROLLER_DECLSPEC BitwiseXorGenerator
+        : public BinaryArithmeticGenerator<Expression::BitwiseXor>
     {
     public:
         BitwiseXorGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/Conditional.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/Conditional.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,15 +35,16 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<TernaryArithmeticGenerator<Expression::Conditional>>
-        GetGenerator<Expression::Conditional>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<TernaryArithmeticGenerator<Expression::Conditional>>
+                       GetGenerator<Expression::Conditional>(Register::ValuePtr dst,
                                               Register::ValuePtr lhs,
                                               Register::ValuePtr r1hs,
                                               Register::ValuePtr r2hsw,
                                               Expression::Conditional const&);
 
     // Generator for all register types and datatypes.
-    class ConditionalGenerator : public TernaryArithmeticGenerator<Expression::Conditional>
+    class ROCROLLER_DECLSPEC ConditionalGenerator
+        : public TernaryArithmeticGenerator<Expression::Conditional>
     {
     public:
         ConditionalGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/Convert.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/Convert.hpp
@@ -26,13 +26,15 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     template <>
-    std::shared_ptr<UnaryArithmeticGenerator<Expression::Convert>>
-        GetGenerator<Expression::Convert>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<UnaryArithmeticGenerator<Expression::Convert>>
+                       GetGenerator<Expression::Convert>(Register::ValuePtr dst,
                                           Register::ValuePtr arg,
                                           Expression::Convert const&);
     /**
@@ -46,7 +48,7 @@ namespace rocRoller
     Generator<Instruction>
         generateConvertOp(DataType dataType, Register::ValuePtr dest, Register::ValuePtr arg);
 
-    class ConvertGenerator : public UnaryArithmeticGenerator<Expression::Convert>
+    class ROCROLLER_DECLSPEC ConvertGenerator : public UnaryArithmeticGenerator<Expression::Convert>
     {
     public:
         ConvertGenerator(ContextPtr c)
@@ -122,7 +124,8 @@ namespace rocRoller
      *  the second arg is a seed for stochastic rounding.
      */
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::SRConvert<DataType::FP8>>>
+    ROCROLLER_DECLSPEC
+        std::shared_ptr<BinaryArithmeticGenerator<Expression::SRConvert<DataType::FP8>>>
         GetGenerator<Expression::SRConvert<DataType::FP8>>(
             Register::ValuePtr dst,
             Register::ValuePtr lhs,
@@ -130,7 +133,8 @@ namespace rocRoller
             Expression::SRConvert<DataType::FP8> const&);
 
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::SRConvert<DataType::BF8>>>
+    ROCROLLER_DECLSPEC
+        std::shared_ptr<BinaryArithmeticGenerator<Expression::SRConvert<DataType::BF8>>>
         GetGenerator<Expression::SRConvert<DataType::BF8>>(
             Register::ValuePtr dst,
             Register::ValuePtr lhs,
@@ -139,7 +143,8 @@ namespace rocRoller
 
     // Templated Generator class based on the return type.
     template <DataType DATATYPE>
-    class SRConvertGenerator : public BinaryArithmeticGenerator<Expression::SRConvert<DATATYPE>>
+    class ROCROLLER_DECLSPEC SRConvertGenerator
+        : public BinaryArithmeticGenerator<Expression::SRConvert<DATATYPE>>
     {
     public:
         SRConvertGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/Divide.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/Divide.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,15 +35,15 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::Divide>>
-        GetGenerator<Expression::Divide>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::Divide>>
+                       GetGenerator<Expression::Divide>(Register::ValuePtr dst,
                                          Register::ValuePtr lhs,
                                          Register::ValuePtr rhs,
                                          Expression::Divide const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class DivideGenerator : public BinaryArithmeticGenerator<Expression::Divide>
+    class ROCROLLER_DECLSPEC DivideGenerator : public BinaryArithmeticGenerator<Expression::Divide>
     {
     public:
         DivideGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/Equal.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/Equal.hpp
@@ -26,21 +26,23 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::Equal>>
-        GetGenerator<Expression::Equal>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::Equal>>
+                       GetGenerator<Expression::Equal>(Register::ValuePtr dst,
                                         Register::ValuePtr lhs,
                                         Register::ValuePtr rhs,
                                         Expression::Equal const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class EqualGenerator : public BinaryArithmeticGenerator<Expression::Equal>
+    class ROCROLLER_DECLSPEC EqualGenerator : public BinaryArithmeticGenerator<Expression::Equal>
     {
     public:
         EqualGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/Exponential2.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/Exponential2.hpp
@@ -26,20 +26,23 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<UnaryArithmeticGenerator<Expression::Exponential2>>
-        GetGenerator<Expression::Exponential2>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<UnaryArithmeticGenerator<Expression::Exponential2>>
+                       GetGenerator<Expression::Exponential2>(Register::ValuePtr dst,
                                                Register::ValuePtr arg,
                                                Expression::Exponential2 const&);
 
     // Templated Generator class based on the return type.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class Exponential2Generator : public UnaryArithmeticGenerator<Expression::Exponential2>
+    class ROCROLLER_DECLSPEC Exponential2Generator
+        : public UnaryArithmeticGenerator<Expression::Exponential2>
     {
     public:
         Exponential2Generator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/GreaterThan.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/GreaterThan.hpp
@@ -26,21 +26,24 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::GreaterThan>>
-        GetGenerator<Expression::GreaterThan>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::GreaterThan>>
+                       GetGenerator<Expression::GreaterThan>(Register::ValuePtr dst,
                                               Register::ValuePtr lhs,
                                               Register::ValuePtr rhs,
                                               Expression::GreaterThan const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class GreaterThanGenerator : public BinaryArithmeticGenerator<Expression::GreaterThan>
+    class ROCROLLER_DECLSPEC GreaterThanGenerator
+        : public BinaryArithmeticGenerator<Expression::GreaterThan>
     {
     public:
         GreaterThanGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/GreaterThanEqual.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/GreaterThanEqual.hpp
@@ -26,21 +26,24 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::GreaterThanEqual>>
-        GetGenerator<Expression::GreaterThanEqual>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::GreaterThanEqual>>
+                       GetGenerator<Expression::GreaterThanEqual>(Register::ValuePtr dst,
                                                    Register::ValuePtr lhs,
                                                    Register::ValuePtr rhs,
                                                    Expression::GreaterThanEqual const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class GreaterThanEqualGenerator : public BinaryArithmeticGenerator<Expression::GreaterThanEqual>
+    class ROCROLLER_DECLSPEC GreaterThanEqualGenerator
+        : public BinaryArithmeticGenerator<Expression::GreaterThanEqual>
     {
     public:
         GreaterThanEqualGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/LessThan.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/LessThan.hpp
@@ -26,21 +26,24 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::LessThan>>
-        GetGenerator<Expression::LessThan>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::LessThan>>
+                       GetGenerator<Expression::LessThan>(Register::ValuePtr dst,
                                            Register::ValuePtr lhs,
                                            Register::ValuePtr rhs,
                                            Expression::LessThan const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class LessThanGenerator : public BinaryArithmeticGenerator<Expression::LessThan>
+    class ROCROLLER_DECLSPEC LessThanGenerator
+        : public BinaryArithmeticGenerator<Expression::LessThan>
     {
     public:
         LessThanGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/LessThanEqual.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/LessThanEqual.hpp
@@ -26,21 +26,24 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::LessThanEqual>>
-        GetGenerator<Expression::LessThanEqual>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::LessThanEqual>>
+                       GetGenerator<Expression::LessThanEqual>(Register::ValuePtr dst,
                                                 Register::ValuePtr lhs,
                                                 Register::ValuePtr rhs,
                                                 Expression::LessThanEqual const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class LessThanEqualGenerator : public BinaryArithmeticGenerator<Expression::LessThanEqual>
+    class ROCROLLER_DECLSPEC LessThanEqualGenerator
+        : public BinaryArithmeticGenerator<Expression::LessThanEqual>
     {
     public:
         LessThanEqualGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/LogicalAnd.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/LogicalAnd.hpp
@@ -26,21 +26,24 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::LogicalAnd>>
-        GetGenerator<Expression::LogicalAnd>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::LogicalAnd>>
+                       GetGenerator<Expression::LogicalAnd>(Register::ValuePtr dst,
                                              Register::ValuePtr lhs,
                                              Register::ValuePtr rhs,
                                              Expression::LogicalAnd const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class LogicalAndGenerator : public BinaryArithmeticGenerator<Expression::LogicalAnd>
+    class ROCROLLER_DECLSPEC LogicalAndGenerator
+        : public BinaryArithmeticGenerator<Expression::LogicalAnd>
     {
     public:
         LogicalAndGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/LogicalNot.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/LogicalNot.hpp
@@ -26,20 +26,23 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<UnaryArithmeticGenerator<Expression::LogicalNot>>
-        GetGenerator<Expression::LogicalNot>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<UnaryArithmeticGenerator<Expression::LogicalNot>>
+                       GetGenerator<Expression::LogicalNot>(Register::ValuePtr dst,
                                              Register::ValuePtr arg,
                                              Expression::LogicalNot const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class LogicalNotGenerator : public UnaryArithmeticGenerator<Expression::LogicalNot>
+    class ROCROLLER_DECLSPEC LogicalNotGenerator
+        : public UnaryArithmeticGenerator<Expression::LogicalNot>
     {
     public:
         LogicalNotGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/LogicalOr.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/LogicalOr.hpp
@@ -26,21 +26,24 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::LogicalOr>>
-        GetGenerator<Expression::LogicalOr>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::LogicalOr>>
+                       GetGenerator<Expression::LogicalOr>(Register::ValuePtr dst,
                                             Register::ValuePtr lhs,
                                             Register::ValuePtr rhs,
                                             Expression::LogicalOr const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class LogicalOrGenerator : public BinaryArithmeticGenerator<Expression::LogicalOr>
+    class ROCROLLER_DECLSPEC LogicalOrGenerator
+        : public BinaryArithmeticGenerator<Expression::LogicalOr>
     {
     public:
         LogicalOrGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/LogicalShiftR.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/LogicalShiftR.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,14 +35,15 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::LogicalShiftR>>
-        GetGenerator<Expression::LogicalShiftR>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::LogicalShiftR>>
+                       GetGenerator<Expression::LogicalShiftR>(Register::ValuePtr dst,
                                                 Register::ValuePtr lhs,
                                                 Register::ValuePtr rhs,
                                                 Expression::LogicalShiftR const&);
 
     // Generator for all register types and datatypes.
-    class LogicalShiftRGenerator : public BinaryArithmeticGenerator<Expression::LogicalShiftR>
+    class ROCROLLER_DECLSPEC LogicalShiftRGenerator
+        : public BinaryArithmeticGenerator<Expression::LogicalShiftR>
     {
     public:
         LogicalShiftRGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/MatrixMultiply.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/MatrixMultiply.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 #include <tuple>
 
@@ -36,7 +38,7 @@ namespace rocRoller
 {
     namespace InstructionGenerators
     {
-        struct MatrixMultiply
+        struct ROCROLLER_DECLSPEC MatrixMultiply
         {
             /**
              * Context, accumulation type, input type.
@@ -65,7 +67,7 @@ namespace rocRoller
                 = 0;
         };
 
-        struct MatrixMultiplyGenerator : public MatrixMultiply
+        struct ROCROLLER_DECLSPEC MatrixMultiplyGenerator : public MatrixMultiply
         {
             using Base = MatrixMultiply;
 

--- a/lib/include/rocRoller/CodeGen/Arithmetic/MatrixMultiply_fwd.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/MatrixMultiply_fwd.hpp
@@ -26,13 +26,15 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 namespace rocRoller
 {
     namespace InstructionGenerators
     {
-        struct MatrixMultiply;
+        struct ROCROLLER_DECLSPEC MatrixMultiply;
         using MatrixMultiplyPtr = std::shared_ptr<MatrixMultiply>;
     }
 }

--- a/lib/include/rocRoller/CodeGen/Arithmetic/Modulo.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/Modulo.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,15 +35,15 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::Modulo>>
-        GetGenerator<Expression::Modulo>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::Modulo>>
+                       GetGenerator<Expression::Modulo>(Register::ValuePtr dst,
                                          Register::ValuePtr lhs,
                                          Register::ValuePtr rhs,
                                          Expression::Modulo const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class ModuloGenerator : public BinaryArithmeticGenerator<Expression::Modulo>
+    class ROCROLLER_DECLSPEC ModuloGenerator : public BinaryArithmeticGenerator<Expression::Modulo>
     {
     public:
         ModuloGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/Multiply.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/Multiply.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,15 +35,16 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::Multiply>>
-        GetGenerator<Expression::Multiply>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::Multiply>>
+                       GetGenerator<Expression::Multiply>(Register::ValuePtr dst,
                                            Register::ValuePtr lhs,
                                            Register::ValuePtr rhs,
                                            Expression::Multiply const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class MultiplyGenerator : public BinaryArithmeticGenerator<Expression::Multiply>
+    class ROCROLLER_DECLSPEC MultiplyGenerator
+        : public BinaryArithmeticGenerator<Expression::Multiply>
     {
     public:
         MultiplyGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/MultiplyAdd.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/MultiplyAdd.hpp
@@ -26,19 +26,22 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     template <>
-    std::shared_ptr<TernaryArithmeticGenerator<Expression::MultiplyAdd>>
-        GetGenerator<Expression::MultiplyAdd>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<TernaryArithmeticGenerator<Expression::MultiplyAdd>>
+                       GetGenerator<Expression::MultiplyAdd>(Register::ValuePtr dst,
                                               Register::ValuePtr a,
                                               Register::ValuePtr x,
                                               Register::ValuePtr y,
                                               Expression::MultiplyAdd const&);
 
-    struct MultiplyAddGenerator : public TernaryArithmeticGenerator<Expression::MultiplyAdd>
+    struct ROCROLLER_DECLSPEC MultiplyAddGenerator
+        : public TernaryArithmeticGenerator<Expression::MultiplyAdd>
     {
         MultiplyAddGenerator(ContextPtr c)
             : TernaryArithmeticGenerator<Expression::MultiplyAdd>(c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/MultiplyHigh.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/MultiplyHigh.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,14 +35,15 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::MultiplyHigh>>
-        GetGenerator<Expression::MultiplyHigh>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::MultiplyHigh>>
+                       GetGenerator<Expression::MultiplyHigh>(Register::ValuePtr dst,
                                                Register::ValuePtr lhs,
                                                Register::ValuePtr rhs,
                                                Expression::MultiplyHigh const&);
 
     // Generator for all register types and datatypes.
-    class MultiplyHighGenerator : public BinaryArithmeticGenerator<Expression::MultiplyHigh>
+    class ROCROLLER_DECLSPEC MultiplyHighGenerator
+        : public BinaryArithmeticGenerator<Expression::MultiplyHigh>
     {
     public:
         MultiplyHighGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/Negate.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/Negate.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,11 +35,13 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<UnaryArithmeticGenerator<Expression::Negate>> GetGenerator<Expression::Negate>(
-        Register::ValuePtr dst, Register::ValuePtr arg, Expression::Negate const&);
+    ROCROLLER_DECLSPEC std::shared_ptr<UnaryArithmeticGenerator<Expression::Negate>>
+                       GetGenerator<Expression::Negate>(Register::ValuePtr dst,
+                                         Register::ValuePtr arg,
+                                         Expression::Negate const&);
 
     // Templated Generator class based on the return type.
-    class NegateGenerator : public UnaryArithmeticGenerator<Expression::Negate>
+    class ROCROLLER_DECLSPEC NegateGenerator : public UnaryArithmeticGenerator<Expression::Negate>
     {
     public:
         NegateGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/NotEqual.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/NotEqual.hpp
@@ -26,21 +26,24 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::NotEqual>>
-        GetGenerator<Expression::NotEqual>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::NotEqual>>
+                       GetGenerator<Expression::NotEqual>(Register::ValuePtr dst,
                                            Register::ValuePtr lhs,
                                            Register::ValuePtr rhs,
                                            Expression::NotEqual const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class NotEqualGenerator : public BinaryArithmeticGenerator<Expression::NotEqual>
+    class ROCROLLER_DECLSPEC NotEqualGenerator
+        : public BinaryArithmeticGenerator<Expression::NotEqual>
     {
     public:
         NotEqualGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/RandomNumber.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/RandomNumber.hpp
@@ -26,19 +26,22 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
 {
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<UnaryArithmeticGenerator<Expression::RandomNumber>>
-        GetGenerator<Expression::RandomNumber>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<UnaryArithmeticGenerator<Expression::RandomNumber>>
+                       GetGenerator<Expression::RandomNumber>(Register::ValuePtr dst,
                                                Register::ValuePtr arg,
                                                Expression::RandomNumber const&);
 
     // Templated Generator class based on the register type and datatype.
-    class RandomNumberGenerator : public UnaryArithmeticGenerator<Expression::RandomNumber>
+    class ROCROLLER_DECLSPEC RandomNumberGenerator
+        : public UnaryArithmeticGenerator<Expression::RandomNumber>
     {
     public:
         RandomNumberGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/ScaledMatrixMultiply.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/ScaledMatrixMultiply.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include "ScaledMatrixMultiply_fwd.hpp"
 
 #include <memory>
@@ -37,7 +39,7 @@ namespace rocRoller
 {
     namespace InstructionGenerators
     {
-        struct ScaledMatrixMultiply
+        struct ROCROLLER_DECLSPEC ScaledMatrixMultiply
         {
             /**
              * Context, accumulation type, input type.
@@ -67,7 +69,7 @@ namespace rocRoller
                 = 0;
         };
 
-        struct ScaledMatrixMultiplyGenerator : public ScaledMatrixMultiply
+        struct ROCROLLER_DECLSPEC ScaledMatrixMultiplyGenerator : public ScaledMatrixMultiply
         {
             static bool constexpr isValidInputType(auto const vtype)
             {

--- a/lib/include/rocRoller/CodeGen/Arithmetic/ScaledMatrixMultiply_fwd.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/ScaledMatrixMultiply_fwd.hpp
@@ -26,13 +26,15 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 namespace rocRoller
 {
     namespace InstructionGenerators
     {
-        struct ScaledMatrixMultiply;
+        struct ROCROLLER_DECLSPEC ScaledMatrixMultiply;
         using ScaledMatrixMultiplyPtr = std::shared_ptr<ScaledMatrixMultiply>;
     }
 }

--- a/lib/include/rocRoller/CodeGen/Arithmetic/ShiftL.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/ShiftL.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,14 +35,14 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::ShiftL>>
-        GetGenerator<Expression::ShiftL>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::ShiftL>>
+                       GetGenerator<Expression::ShiftL>(Register::ValuePtr dst,
                                          Register::ValuePtr lhs,
                                          Register::ValuePtr rhs,
                                          Expression::ShiftL const&);
 
     // Generator for all register types and datatypes.
-    class ShiftLGenerator : public BinaryArithmeticGenerator<Expression::ShiftL>
+    class ROCROLLER_DECLSPEC ShiftLGenerator : public BinaryArithmeticGenerator<Expression::ShiftL>
     {
     public:
         ShiftLGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/ShiftLAdd.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/ShiftLAdd.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,15 +35,16 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<TernaryArithmeticGenerator<Expression::ShiftLAdd>>
-        GetGenerator<Expression::ShiftLAdd>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<TernaryArithmeticGenerator<Expression::ShiftLAdd>>
+                       GetGenerator<Expression::ShiftLAdd>(Register::ValuePtr dst,
                                             Register::ValuePtr lhs,
                                             Register::ValuePtr shiftAmount,
                                             Register::ValuePtr rhs,
                                             Expression::ShiftLAdd const&);
 
     // Generator for all register types and datatypes.
-    class ShiftLAddGenerator : public TernaryArithmeticGenerator<Expression::ShiftLAdd>
+    class ROCROLLER_DECLSPEC ShiftLAddGenerator
+        : public TernaryArithmeticGenerator<Expression::ShiftLAdd>
     {
     public:
         ShiftLAddGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/Subtract.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/Subtract.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Arithmetic/ArithmeticGenerator.hpp>
 
 namespace rocRoller
@@ -33,15 +35,16 @@ namespace rocRoller
 
     // GetGenerator function will return the Generator to use based on the provided arguments.
     template <>
-    std::shared_ptr<BinaryArithmeticGenerator<Expression::Subtract>>
-        GetGenerator<Expression::Subtract>(Register::ValuePtr dst,
+    ROCROLLER_DECLSPEC std::shared_ptr<BinaryArithmeticGenerator<Expression::Subtract>>
+                       GetGenerator<Expression::Subtract>(Register::ValuePtr dst,
                                            Register::ValuePtr lhs,
                                            Register::ValuePtr rhs,
                                            Expression::Subtract const&);
 
     // Templated Generator class based on the register type and datatype.
     template <Register::Type REGISTER_TYPE, DataType DATATYPE>
-    class SubtractGenerator : public BinaryArithmeticGenerator<Expression::Subtract>
+    class ROCROLLER_DECLSPEC SubtractGenerator
+        : public BinaryArithmeticGenerator<Expression::Subtract>
     {
     public:
         SubtractGenerator(ContextPtr c)

--- a/lib/include/rocRoller/CodeGen/Arithmetic/Utility.hpp
+++ b/lib/include/rocRoller/CodeGen/Arithmetic/Utility.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/InstructionValues/Register.hpp>
 
 namespace rocRoller
@@ -35,13 +37,13 @@ namespace rocRoller
         /**
          * @brief Represent a single Register::Value as two Register::Values each the size of a single DWord
         */
-        void get2LiteralDwords(Register::ValuePtr& lsd,
-                               Register::ValuePtr& msd,
-                               Register::ValuePtr  input);
+        ROCROLLER_DECLSPEC void get2LiteralDwords(Register::ValuePtr& lsd,
+                                                  Register::ValuePtr& msd,
+                                                  Register::ValuePtr  input);
 
         /**
          * @brief Get the modifier string for MFMA's input matrix types
         */
-        std::string getModifier(DataType dataType);
+        ROCROLLER_DECLSPEC std::string getModifier(DataType dataType);
     }
 }

--- a/lib/include/rocRoller/CodeGen/BranchGenerator.hpp
+++ b/lib/include/rocRoller/CodeGen/BranchGenerator.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Instruction.hpp>
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/Utilities/Component.hpp>
@@ -36,7 +38,7 @@ namespace rocRoller
     /**
      * @brief Generator for generating conditional and unconditional branches.
      */
-    class BranchGenerator
+    class ROCROLLER_DECLSPEC BranchGenerator
     {
     public:
         BranchGenerator(ContextPtr);

--- a/lib/include/rocRoller/CodeGen/BranchGenerator_fwd.hpp
+++ b/lib/include/rocRoller/CodeGen/BranchGenerator_fwd.hpp
@@ -26,9 +26,11 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
 
-    class BranchGenerator;
+    class ROCROLLER_DECLSPEC BranchGenerator;
 
 }

--- a/lib/include/rocRoller/CodeGen/Buffer.hpp
+++ b/lib/include/rocRoller/CodeGen/Buffer.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <functional>
 #include <memory>
 
@@ -38,7 +40,7 @@
 
 namespace rocRoller
 {
-    struct GFX9BufferDescriptorOptions
+    struct ROCROLLER_DECLSPEC GFX9BufferDescriptorOptions
     {
         enum DataFormatValue
         {
@@ -87,14 +89,14 @@ namespace rocRoller
         void validate() const;
     };
 
-    std::string   toString(GFX9BufferDescriptorOptions::DataFormatValue val);
-    std::ostream& operator<<(std::ostream&                                stream,
-                             GFX9BufferDescriptorOptions::DataFormatValue val);
+    ROCROLLER_DECLSPEC std::string toString(GFX9BufferDescriptorOptions::DataFormatValue val);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&                                stream,
+                                                GFX9BufferDescriptorOptions::DataFormatValue val);
 
     static_assert(sizeof(GFX9BufferDescriptorOptions) == 4);
     static_assert(GFX9BufferDescriptorOptions::DFReserved == 15);
 
-    class BufferDescriptor
+    class ROCROLLER_DECLSPEC BufferDescriptor
     {
     public:
         BufferDescriptor(Register::ValuePtr srd, ContextPtr context);

--- a/lib/include/rocRoller/CodeGen/BufferInstructionOptions.hpp
+++ b/lib/include/rocRoller/CodeGen/BufferInstructionOptions.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Utilities/Error.hpp>
 
 /**
@@ -38,7 +40,7 @@
 
 namespace rocRoller
 {
-    struct BufferInstructionOptions
+    struct ROCROLLER_DECLSPEC BufferInstructionOptions
     {
         bool offen = false;
         bool glc   = false;

--- a/lib/include/rocRoller/CodeGen/CopyGenerator.hpp
+++ b/lib/include/rocRoller/CodeGen/CopyGenerator.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Instruction.hpp>
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/Utilities/Component.hpp>
@@ -37,7 +39,7 @@ namespace rocRoller
      * Co-yields `mov` instructions automatically from a `src` to `dest`
      * if the copy is valid.
      */
-    class CopyGenerator
+    class ROCROLLER_DECLSPEC CopyGenerator
     {
     public:
         CopyGenerator(ContextPtr);

--- a/lib/include/rocRoller/CodeGen/CopyGenerator_fwd.hpp
+++ b/lib/include/rocRoller/CodeGen/CopyGenerator_fwd.hpp
@@ -26,9 +26,11 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
 
-    class CopyGenerator;
+    class ROCROLLER_DECLSPEC CopyGenerator;
 
 }

--- a/lib/include/rocRoller/CodeGen/CrashKernelGenerator.hpp
+++ b/lib/include/rocRoller/CodeGen/CrashKernelGenerator.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/AssertOpKinds_fwd.hpp>
 #include <rocRoller/CodeGen/Instruction.hpp>
 #include <rocRoller/Context_fwd.hpp>
@@ -34,7 +36,7 @@
 
 namespace rocRoller
 {
-    class CrashKernelGenerator
+    class ROCROLLER_DECLSPEC CrashKernelGenerator
     {
     public:
         CrashKernelGenerator(ContextPtr);

--- a/lib/include/rocRoller/CodeGen/CrashKernelGenerator_fwd.hpp
+++ b/lib/include/rocRoller/CodeGen/CrashKernelGenerator_fwd.hpp
@@ -26,9 +26,11 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
 
-    class CrashKernelGenerator;
+    class ROCROLLER_DECLSPEC CrashKernelGenerator;
 
 }

--- a/lib/include/rocRoller/CodeGen/Instruction.hpp
+++ b/lib/include/rocRoller/CodeGen/Instruction.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 #include <string>
 
@@ -37,7 +39,7 @@
 
 namespace rocRoller
 {
-    struct Instruction
+    struct ROCROLLER_DECLSPEC Instruction
     {
         enum
         {

--- a/lib/include/rocRoller/CodeGen/Instruction_fwd.hpp
+++ b/lib/include/rocRoller/CodeGen/Instruction_fwd.hpp
@@ -26,9 +26,11 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
 
-    class Instruction;
+    struct ROCROLLER_DECLSPEC Instruction;
 
 }

--- a/lib/include/rocRoller/CodeGen/LoadStoreTileGenerator.hpp
+++ b/lib/include/rocRoller/CodeGen/LoadStoreTileGenerator.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/MemoryInstructions.hpp>
 #include <rocRoller/KernelGraph/CoordinateGraph/Transformer.hpp>
 #include <rocRoller/KernelGraph/KernelGraph.hpp>
@@ -43,7 +45,7 @@ namespace rocRoller
          *        to and from memory.
          *
          */
-        class LoadStoreTileGenerator
+        class ROCROLLER_DECLSPEC LoadStoreTileGenerator
         {
         public:
             LoadStoreTileGenerator(KernelGraphPtr, ContextPtr, unsigned int);
@@ -124,7 +126,7 @@ namespace rocRoller
             /**
              * Information needed in order to load or store a tile.
              */
-            struct LoadStoreTileInfo
+            struct ROCROLLER_DECLSPEC LoadStoreTileInfo
             {
                 MemoryInstructions::MemoryKind    kind = MemoryInstructions::MemoryKind::Count;
                 uint64_t                          m    = 0;

--- a/lib/include/rocRoller/CodeGen/MemoryInstructions.hpp
+++ b/lib/include/rocRoller/CodeGen/MemoryInstructions.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Buffer.hpp>
 #include <rocRoller/CodeGen/BufferInstructionOptions.hpp>
 #include <rocRoller/CodeGen/CopyGenerator.hpp>
@@ -36,7 +38,7 @@
 namespace rocRoller
 {
 
-    class MemoryInstructions
+    class ROCROLLER_DECLSPEC MemoryInstructions
     {
     public:
         MemoryInstructions(ContextPtr context);
@@ -384,11 +386,13 @@ namespace rocRoller
                                             Register::ValuePtr  toPack) const;
     };
 
-    std::string   toString(MemoryInstructions::MemoryDirection const& d);
-    std::ostream& operator<<(std::ostream& stream, MemoryInstructions::MemoryDirection n);
+    ROCROLLER_DECLSPEC std::string toString(MemoryInstructions::MemoryDirection const& d);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&                       stream,
+                                                MemoryInstructions::MemoryDirection n);
 
-    std::string   toString(MemoryInstructions::MemoryKind const& k);
-    std::ostream& operator<<(std::ostream& stream, MemoryInstructions::MemoryKind k);
+    ROCROLLER_DECLSPEC std::string toString(MemoryInstructions::MemoryKind const& k);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&                  stream,
+                                                MemoryInstructions::MemoryKind k);
 }
 
 #include <rocRoller/CodeGen/MemoryInstructions_impl.hpp>

--- a/lib/include/rocRoller/CodeGen/MemoryInstructions_fwd.hpp
+++ b/lib/include/rocRoller/CodeGen/MemoryInstructions_fwd.hpp
@@ -26,9 +26,11 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
 
-    class MemoryInstructions;
+    class ROCROLLER_DECLSPEC MemoryInstructions;
 
 }

--- a/lib/include/rocRoller/CodeGen/Utils.hpp
+++ b/lib/include/rocRoller/CodeGen/Utils.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 
 namespace rocRoller
@@ -37,7 +39,7 @@ namespace rocRoller
    *
    * @param elementBits number of bits of variable type to load.
    */
-    uint bitsPerTransposeLoad(uint elementBits);
+    ROCROLLER_DECLSPEC uint bitsPerTransposeLoad(uint elementBits);
 
     /**
    * @brief Returns extra number of bytes required to fulfill 128b alignment requirement of 6-bit transpose loads.
@@ -46,7 +48,7 @@ namespace rocRoller
    *
    * @param elementBits number of bits of variable type to load.
    */
-    uint extraLDSBytesPerElementBlock(uint elementBits);
+    ROCROLLER_DECLSPEC uint extraLDSBytesPerElementBlock(uint elementBits);
 
-    std::string transposeLoadMnemonic(uint elementBits);
+    ROCROLLER_DECLSPEC std::string transposeLoadMnemonic(uint elementBits);
 } // rocRoller

--- a/lib/include/rocRoller/CodeGen/WaitCount.hpp
+++ b/lib/include/rocRoller/CodeGen/WaitCount.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 #include <vector>
 
@@ -44,7 +46,7 @@ namespace rocRoller
      *
      * Internally represents -1 as not having to wait for a particular counter.
      */
-    class WaitCount
+    class ROCROLLER_DECLSPEC WaitCount
     {
     public:
         WaitCount() = default;
@@ -144,5 +146,5 @@ namespace rocRoller
         bool m_hasEXPCnt      = false;
     };
 
-    std::ostream& operator<<(std::ostream& stream, WaitCount const& wait);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, WaitCount const& wait);
 }

--- a/lib/include/rocRoller/CodeGen/WaitCount_fwd.hpp
+++ b/lib/include/rocRoller/CodeGen/WaitCount_fwd.hpp
@@ -26,7 +26,9 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
-    class WaitCount;
+    class ROCROLLER_DECLSPEC WaitCount;
 }

--- a/lib/include/rocRoller/CommandSolution.hpp
+++ b/lib/include/rocRoller/CommandSolution.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 #include <rocRoller/CommandSolution_fwd.hpp>
@@ -51,7 +53,7 @@ namespace rocRoller
     /**
      * CommandParameters - tunable command parameters.
      */
-    class CommandParameters
+    class ROCROLLER_DECLSPEC CommandParameters
     {
     public:
         CommandParameters();
@@ -157,7 +159,7 @@ namespace rocRoller
      *
      * TODO: Remove this!
      */
-    class CommandLaunchParameters
+    class ROCROLLER_DECLSPEC CommandLaunchParameters
     {
     public:
         CommandLaunchParameters() = default;
@@ -172,7 +174,7 @@ namespace rocRoller
         std::optional<std::array<Expression::ExpressionPtr, 3>> m_workitemCount;
     };
 
-    class CommandKernel
+    class ROCROLLER_DECLSPEC CommandKernel
     {
     public:
         CommandKernel() = default;
@@ -351,7 +353,7 @@ namespace rocRoller
                           hipStream_t               stream);
     };
 
-    class CommandSolution
+    class ROCROLLER_DECLSPEC CommandSolution
     {
     public:
         explicit CommandSolution(CommandPtr command);

--- a/lib/include/rocRoller/CommandSolution_fwd.hpp
+++ b/lib/include/rocRoller/CommandSolution_fwd.hpp
@@ -26,14 +26,16 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 namespace rocRoller
 {
-    class CommandParameters;
-    class CommandLaunchParameters;
-    class CommandKernel;
-    class CommandSolution;
+    class ROCROLLER_DECLSPEC CommandParameters;
+    class ROCROLLER_DECLSPEC CommandLaunchParameters;
+    class ROCROLLER_DECLSPEC CommandKernel;
+    class ROCROLLER_DECLSPEC CommandSolution;
 
     using CommandParametersPtr       = std::shared_ptr<CommandParameters>;
     using CommandKernelPtr           = std::shared_ptr<CommandKernel>;

--- a/lib/include/rocRoller/CommonSubexpressionElim.hpp
+++ b/lib/include/rocRoller/CommonSubexpressionElim.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/Expression_fwd.hpp>
 #include <set>
@@ -35,7 +37,7 @@ namespace rocRoller
 {
     namespace Expression
     {
-        struct ExpressionNode
+        struct ROCROLLER_DECLSPEC ExpressionNode
         {
             /**
              * The destination register for the expression.
@@ -85,7 +87,8 @@ namespace rocRoller
          * @param context
          * @return ExpressionTree
          */
-        ExpressionTree consolidateSubExpressions(ExpressionPtr expr, ContextPtr context);
+        ROCROLLER_DECLSPEC ExpressionTree consolidateSubExpressions(ExpressionPtr expr,
+                                                                    ContextPtr    context);
 
         /**
          * @brief Get the number of consolidations performed by Common Subexpression Elimination
@@ -93,7 +96,7 @@ namespace rocRoller
          * @param tree Tree to fetch count from
          * @return Count of subexpressions consolidatated from original expression
          */
-        int getConsolidationCount(ExpressionTree const& tree);
+        ROCROLLER_DECLSPEC int getConsolidationCount(ExpressionTree const& tree);
 
         /**
          * @brief Rebuilds an Expression from an ExpressionTree
@@ -101,6 +104,6 @@ namespace rocRoller
          * @param tree The tree to rebuild
          * @return ExpressionPtr
          */
-        ExpressionPtr rebuildExpression(ExpressionTree const& tree);
+        ROCROLLER_DECLSPEC ExpressionPtr rebuildExpression(ExpressionTree const& tree);
     }
 }

--- a/lib/include/rocRoller/Context.hpp
+++ b/lib/include/rocRoller/Context.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -57,11 +59,11 @@
 #include <rocRoller/Scheduling/Scheduling_fwd.hpp>
 #include <rocRoller/Utilities/Random_fwd.hpp>
 
-class ContextFixture;
+class ROCROLLER_DECLSPEC ContextFixture;
 
 namespace rocRoller
 {
-    class Context : public std::enable_shared_from_this<Context>
+    class ROCROLLER_DECLSPEC Context : public std::enable_shared_from_this<Context>
     {
     public:
         Context();
@@ -184,7 +186,7 @@ namespace rocRoller
         KernelOptions m_kernelOptions;
     };
 
-    std::ostream& operator<<(std::ostream&, ContextPtr const&);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, ContextPtr const&);
 }
 
 #include <rocRoller/Context_impl.hpp>

--- a/lib/include/rocRoller/Context_fwd.hpp
+++ b/lib/include/rocRoller/Context_fwd.hpp
@@ -26,11 +26,13 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 namespace rocRoller
 {
-    class Context;
+    class ROCROLLER_DECLSPEC Context;
 
     using ContextPtr = std::shared_ptr<Context>;
 }

--- a/lib/include/rocRoller/DataTypes/DataTypes.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <cassert>
 #include <complex>
 #include <cstdlib>
@@ -70,8 +72,8 @@ namespace rocRoller
         Count
     };
 
-    std::string   toString(DataDirection dir);
-    std::ostream& operator<<(std::ostream& stream, DataDirection dir);
+    ROCROLLER_DECLSPEC std::string toString(DataDirection dir);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, DataDirection dir);
 
     /**
      * \ingroup DataTypes
@@ -121,10 +123,10 @@ namespace rocRoller
         Count
     };
 
-    std::string   toString(DataType d);
-    std::string   TypeAbbrev(DataType d);
-    std::ostream& operator<<(std::ostream& stream, DataType const& t);
-    std::istream& operator>>(std::istream& stream, DataType& t);
+    ROCROLLER_DECLSPEC std::string toString(DataType d);
+    ROCROLLER_DECLSPEC std::string TypeAbbrev(DataType d);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, DataType const& t);
+    ROCROLLER_DECLSPEC std::istream& operator>>(std::istream& stream, DataType& t);
 
     /**
      * Pointer Type
@@ -159,8 +161,8 @@ namespace rocRoller
         Count
     };
 
-    std::string   toString(MemoryType m);
-    std::ostream& operator<<(std::ostream& stream, MemoryType const& m);
+    ROCROLLER_DECLSPEC std::string toString(MemoryType m);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, MemoryType const& m);
 
     /**
      * Layout of wavetile for MFMA instructions.
@@ -175,8 +177,8 @@ namespace rocRoller
         Count
     };
 
-    std::string   toString(LayoutType l);
-    std::ostream& operator<<(std::ostream& stream, LayoutType l);
+    ROCROLLER_DECLSPEC std::string toString(LayoutType l);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, LayoutType l);
 
     enum class NaryArgument : int
     {
@@ -190,8 +192,8 @@ namespace rocRoller
         None = Count
     };
 
-    std::string   toString(NaryArgument n);
-    std::ostream& operator<<(std::ostream& stream, NaryArgument n);
+    ROCROLLER_DECLSPEC std::string toString(NaryArgument n);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, NaryArgument n);
 
     inline constexpr DataType getIntegerType(bool isSigned, int sizeBytes)
     {
@@ -275,7 +277,7 @@ namespace rocRoller
     /**
      * VariableType
      */
-    struct VariableType
+    struct ROCROLLER_DECLSPEC VariableType
     {
         constexpr VariableType()
             : dataType()
@@ -368,18 +370,18 @@ namespace rocRoller
         static VariableType Promote(VariableType lhs, VariableType rhs);
     };
 
-    std::string   toString(PointerType const& p);
-    std::ostream& operator<<(std::ostream& stream, PointerType const& p);
+    ROCROLLER_DECLSPEC std::string toString(PointerType const& p);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, PointerType const& p);
 
-    std::string   toString(VariableType const& v);
-    std::string   TypeAbbrev(VariableType const& v);
-    std::ostream& operator<<(std::ostream& stream, VariableType const& v);
+    ROCROLLER_DECLSPEC std::string toString(VariableType const& v);
+    ROCROLLER_DECLSPEC std::string TypeAbbrev(VariableType const& v);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, VariableType const& v);
 
     /**
      * \ingroup DataTypes
      * \brief Runtime accessible data type metadata
      */
-    struct DataTypeInfo
+    struct ROCROLLER_DECLSPEC DataTypeInfo
     {
         static DataTypeInfo const& Get(int index);
         static DataTypeInfo const& Get(DataType t);
@@ -428,7 +430,7 @@ namespace rocRoller
      * \brief Compile-time accessible data type metadata.
      */
     template <typename T>
-    struct TypeInfo
+    struct ROCROLLER_DECLSPEC TypeInfo
     {
     };
 
@@ -442,7 +444,7 @@ namespace rocRoller
               bool        T_IsComplex,
               bool        T_IsIntegral,
               bool        T_IsSigned>
-    struct BaseTypeInfo
+    struct ROCROLLER_DECLSPEC BaseTypeInfo
     {
         using Type = T;
 
@@ -643,19 +645,19 @@ namespace rocRoller
                                 T_IsIntegral,
                                 T_IsSigned>::IsIntegral;
 
-#define DeclareDefaultValueTypeInfo(dtype, enumVal)                         \
-    template <>                                                             \
-    struct TypeInfo<dtype> : public BaseTypeInfo<dtype,                     \
-                                                 DataType::enumVal,         \
-                                                 DataType::enumVal,         \
-                                                 PointerType::Value,        \
-                                                 1,                         \
-                                                 1,                         \
-                                                 sizeof(dtype) * 8,         \
-                                                 false,                     \
-                                                 std::is_integral_v<dtype>, \
-                                                 std::is_signed_v<dtype>>   \
-    {                                                                       \
+#define DeclareDefaultValueTypeInfo(dtype, enumVal)                                            \
+    template <>                                                                                \
+    struct ROCROLLER_DECLSPEC TypeInfo<dtype> : public BaseTypeInfo<dtype,                     \
+                                                                    DataType::enumVal,         \
+                                                                    DataType::enumVal,         \
+                                                                    PointerType::Value,        \
+                                                                    1,                         \
+                                                                    1,                         \
+                                                                    sizeof(dtype) * 8,         \
+                                                                    false,                     \
+                                                                    std::is_integral_v<dtype>, \
+                                                                    std::is_signed_v<dtype>>   \
+    {                                                                                          \
     }
 
     DeclareDefaultValueTypeInfo(float, Float);
@@ -671,214 +673,216 @@ namespace rocRoller
 #undef DeclareDefaultValueTypeInfo
 
     template <>
-    struct TypeInfo<uint64_t> : public BaseTypeInfo<uint64_t,
-                                                    DataType::UInt64,
-                                                    DataType::UInt64,
-                                                    PointerType::Value,
-                                                    1,
-                                                    2,
-                                                    64,
-                                                    false,
-                                                    true,
-                                                    false>
+    struct ROCROLLER_DECLSPEC TypeInfo<uint64_t> : public BaseTypeInfo<uint64_t,
+                                                                       DataType::UInt64,
+                                                                       DataType::UInt64,
+                                                                       PointerType::Value,
+                                                                       1,
+                                                                       2,
+                                                                       64,
+                                                                       false,
+                                                                       true,
+                                                                       false>
     {
     };
 
     template <>
-    struct TypeInfo<int64_t> : public BaseTypeInfo<int64_t,
-                                                   DataType::Int64,
-                                                   DataType::Int64,
-                                                   PointerType::Value,
-                                                   1,
-                                                   2,
-                                                   64,
-                                                   false,
-                                                   true,
-                                                   true>
+    struct ROCROLLER_DECLSPEC TypeInfo<int64_t> : public BaseTypeInfo<int64_t,
+                                                                      DataType::Int64,
+                                                                      DataType::Int64,
+                                                                      PointerType::Value,
+                                                                      1,
+                                                                      2,
+                                                                      64,
+                                                                      false,
+                                                                      true,
+                                                                      true>
     {
     };
 
     template <>
-    struct TypeInfo<double> : public BaseTypeInfo<double,
-                                                  DataType::Double,
-                                                  DataType::Double,
-                                                  PointerType::Value,
-                                                  1,
-                                                  2,
-                                                  64,
-                                                  false,
-                                                  false,
-                                                  true>
+    struct ROCROLLER_DECLSPEC TypeInfo<double> : public BaseTypeInfo<double,
+                                                                     DataType::Double,
+                                                                     DataType::Double,
+                                                                     PointerType::Value,
+                                                                     1,
+                                                                     2,
+                                                                     64,
+                                                                     false,
+                                                                     false,
+                                                                     true>
     {
     };
 
     template <>
-    struct TypeInfo<std::complex<float>> : public BaseTypeInfo<std::complex<float>,
-                                                               DataType::ComplexFloat,
-                                                               DataType::ComplexFloat,
-                                                               PointerType::Value,
-                                                               1,
-                                                               2,
-                                                               64,
-                                                               true,
-                                                               false,
-                                                               true>
+    struct ROCROLLER_DECLSPEC TypeInfo<std::complex<float>>
+        : public BaseTypeInfo<std::complex<float>,
+                              DataType::ComplexFloat,
+                              DataType::ComplexFloat,
+                              PointerType::Value,
+                              1,
+                              2,
+                              64,
+                              true,
+                              false,
+                              true>
     {
     };
 
     template <>
-    struct TypeInfo<std::complex<double>> : public BaseTypeInfo<std::complex<double>,
-                                                                DataType::ComplexDouble,
-                                                                DataType::ComplexDouble,
-                                                                PointerType::Value,
-                                                                1,
-                                                                4,
-                                                                128,
-                                                                true,
-                                                                false,
-                                                                true>
+    struct ROCROLLER_DECLSPEC TypeInfo<std::complex<double>>
+        : public BaseTypeInfo<std::complex<double>,
+                              DataType::ComplexDouble,
+                              DataType::ComplexDouble,
+                              PointerType::Value,
+                              1,
+                              4,
+                              128,
+                              true,
+                              false,
+                              true>
     {
     };
 
     template <>
-    struct TypeInfo<Int8x4> : public BaseTypeInfo<Int8x4,
-                                                  DataType::Int8x4,
-                                                  DataType::Int8,
-                                                  PointerType::Value,
-                                                  4,
-                                                  1,
-                                                  32,
-                                                  false,
-                                                  true,
-                                                  true>
+    struct ROCROLLER_DECLSPEC TypeInfo<Int8x4> : public BaseTypeInfo<Int8x4,
+                                                                     DataType::Int8x4,
+                                                                     DataType::Int8,
+                                                                     PointerType::Value,
+                                                                     4,
+                                                                     1,
+                                                                     32,
+                                                                     false,
+                                                                     true,
+                                                                     true>
     {
     };
 
     template <>
-    struct TypeInfo<UInt8x4> : public BaseTypeInfo<UInt8x4,
-                                                   DataType::UInt8x4,
-                                                   DataType::UInt8,
-                                                   PointerType::Value,
-                                                   4,
-                                                   1,
-                                                   32,
-                                                   false,
-                                                   true,
-                                                   false>
+    struct ROCROLLER_DECLSPEC TypeInfo<UInt8x4> : public BaseTypeInfo<UInt8x4,
+                                                                      DataType::UInt8x4,
+                                                                      DataType::UInt8,
+                                                                      PointerType::Value,
+                                                                      4,
+                                                                      1,
+                                                                      32,
+                                                                      false,
+                                                                      true,
+                                                                      false>
     {
     };
 
     template <>
-    struct TypeInfo<Half> : public BaseTypeInfo<Half,
-                                                DataType::Half,
-                                                DataType::Half,
-                                                PointerType::Value,
-                                                1,
-                                                1,
-                                                16,
-                                                false,
-                                                false,
-                                                true>
+    struct ROCROLLER_DECLSPEC TypeInfo<Half> : public BaseTypeInfo<Half,
+                                                                   DataType::Half,
+                                                                   DataType::Half,
+                                                                   PointerType::Value,
+                                                                   1,
+                                                                   1,
+                                                                   16,
+                                                                   false,
+                                                                   false,
+                                                                   true>
     {
     };
 
-    struct Halfx2 : public DistinctType<uint32_t, Halfx2>
-    {
-    };
-
-    template <>
-    struct TypeInfo<Halfx2> : public BaseTypeInfo<Halfx2,
-                                                  DataType::Halfx2,
-                                                  DataType::Half,
-                                                  PointerType::Value,
-                                                  2,
-                                                  1,
-                                                  32,
-                                                  false,
-                                                  false,
-                                                  true>
+    struct ROCROLLER_DECLSPEC Halfx2 : public DistinctType<uint32_t, Halfx2>
     {
     };
 
     template <>
-    struct TypeInfo<FP8> : public BaseTypeInfo<FP8,
-                                               DataType::FP8,
-                                               DataType::FP8,
-                                               PointerType::Value,
-                                               1,
-                                               1,
-                                               8,
-                                               false,
-                                               false,
-                                               true>
-    {
-    };
-
-    struct FP8x4 : public DistinctType<uint32_t, FP8x4>
+    struct ROCROLLER_DECLSPEC TypeInfo<Halfx2> : public BaseTypeInfo<Halfx2,
+                                                                     DataType::Halfx2,
+                                                                     DataType::Half,
+                                                                     PointerType::Value,
+                                                                     2,
+                                                                     1,
+                                                                     32,
+                                                                     false,
+                                                                     false,
+                                                                     true>
     {
     };
 
     template <>
-    struct TypeInfo<FP8x4> : public BaseTypeInfo<FP8x4,
-                                                 DataType::FP8x4,
-                                                 DataType::FP8,
-                                                 PointerType::Value,
-                                                 4,
-                                                 1,
-                                                 32,
-                                                 false,
-                                                 false,
-                                                 true>
+    struct ROCROLLER_DECLSPEC TypeInfo<FP8> : public BaseTypeInfo<FP8,
+                                                                  DataType::FP8,
+                                                                  DataType::FP8,
+                                                                  PointerType::Value,
+                                                                  1,
+                                                                  1,
+                                                                  8,
+                                                                  false,
+                                                                  false,
+                                                                  true>
+    {
+    };
+
+    struct ROCROLLER_DECLSPEC FP8x4 : public DistinctType<uint32_t, FP8x4>
     {
     };
 
     template <>
-    struct TypeInfo<BF8> : public BaseTypeInfo<BF8,
-                                               DataType::BF8,
-                                               DataType::BF8,
-                                               PointerType::Value,
-                                               1,
-                                               1,
-                                               8,
-                                               false,
-                                               false,
-                                               true>
-    {
-    };
-
-    struct BF8x4 : public DistinctType<uint32_t, BF8x4>
+    struct ROCROLLER_DECLSPEC TypeInfo<FP8x4> : public BaseTypeInfo<FP8x4,
+                                                                    DataType::FP8x4,
+                                                                    DataType::FP8,
+                                                                    PointerType::Value,
+                                                                    4,
+                                                                    1,
+                                                                    32,
+                                                                    false,
+                                                                    false,
+                                                                    true>
     {
     };
 
     template <>
-    struct TypeInfo<BF8x4> : public BaseTypeInfo<BF8x4,
-                                                 DataType::BF8x4,
-                                                 DataType::BF8,
-                                                 PointerType::Value,
-                                                 4,
-                                                 1,
-                                                 32,
-                                                 false,
-                                                 false,
-                                                 true>
+    struct ROCROLLER_DECLSPEC TypeInfo<BF8> : public BaseTypeInfo<BF8,
+                                                                  DataType::BF8,
+                                                                  DataType::BF8,
+                                                                  PointerType::Value,
+                                                                  1,
+                                                                  1,
+                                                                  8,
+                                                                  false,
+                                                                  false,
+                                                                  true>
+    {
+    };
+
+    struct ROCROLLER_DECLSPEC BF8x4 : public DistinctType<uint32_t, BF8x4>
     {
     };
 
     template <>
-    struct TypeInfo<FP6> : public BaseTypeInfo<FP6,
-                                               DataType::FP6,
-                                               DataType::FP6,
-                                               PointerType::Value,
-                                               1,
-                                               1,
-                                               6,
-                                               false,
-                                               false,
-                                               true>
+    struct ROCROLLER_DECLSPEC TypeInfo<BF8x4> : public BaseTypeInfo<BF8x4,
+                                                                    DataType::BF8x4,
+                                                                    DataType::BF8,
+                                                                    PointerType::Value,
+                                                                    4,
+                                                                    1,
+                                                                    32,
+                                                                    false,
+                                                                    false,
+                                                                    true>
     {
     };
 
-    struct FP6x16
+    template <>
+    struct ROCROLLER_DECLSPEC TypeInfo<FP6> : public BaseTypeInfo<FP6,
+                                                                  DataType::FP6,
+                                                                  DataType::FP6,
+                                                                  PointerType::Value,
+                                                                  1,
+                                                                  1,
+                                                                  6,
+                                                                  false,
+                                                                  false,
+                                                                  true>
+    {
+    };
+
+    struct ROCROLLER_DECLSPEC FP6x16
     {
         uint32_t a;
         uint32_t b;
@@ -886,34 +890,34 @@ namespace rocRoller
     };
 
     template <>
-    struct TypeInfo<FP6x16> : public BaseTypeInfo<FP6x16,
-                                                  DataType::FP6x16,
-                                                  DataType::FP6,
-                                                  PointerType::Value,
-                                                  16,
-                                                  3,
-                                                  96,
-                                                  false,
-                                                  false,
-                                                  false>
+    struct ROCROLLER_DECLSPEC TypeInfo<FP6x16> : public BaseTypeInfo<FP6x16,
+                                                                     DataType::FP6x16,
+                                                                     DataType::FP6,
+                                                                     PointerType::Value,
+                                                                     16,
+                                                                     3,
+                                                                     96,
+                                                                     false,
+                                                                     false,
+                                                                     false>
     {
     };
 
     template <>
-    struct TypeInfo<BF6> : public BaseTypeInfo<BF6,
-                                               DataType::BF6,
-                                               DataType::BF6,
-                                               PointerType::Value,
-                                               1,
-                                               1,
-                                               6,
-                                               false,
-                                               false,
-                                               true>
+    struct ROCROLLER_DECLSPEC TypeInfo<BF6> : public BaseTypeInfo<BF6,
+                                                                  DataType::BF6,
+                                                                  DataType::BF6,
+                                                                  PointerType::Value,
+                                                                  1,
+                                                                  1,
+                                                                  6,
+                                                                  false,
+                                                                  false,
+                                                                  true>
     {
     };
 
-    struct BF6x16
+    struct ROCROLLER_DECLSPEC BF6x16
     {
         uint32_t a;
         uint32_t b;
@@ -921,188 +925,190 @@ namespace rocRoller
     };
 
     template <>
-    struct TypeInfo<BF6x16> : public BaseTypeInfo<BF6x16,
-                                                  DataType::BF6x16,
-                                                  DataType::BF6,
-                                                  PointerType::Value,
-                                                  16,
-                                                  3,
-                                                  96,
-                                                  false,
-                                                  false,
-                                                  false>
+    struct ROCROLLER_DECLSPEC TypeInfo<BF6x16> : public BaseTypeInfo<BF6x16,
+                                                                     DataType::BF6x16,
+                                                                     DataType::BF6,
+                                                                     PointerType::Value,
+                                                                     16,
+                                                                     3,
+                                                                     96,
+                                                                     false,
+                                                                     false,
+                                                                     false>
     {
     };
 
     template <>
-    struct TypeInfo<FP4> : public BaseTypeInfo<FP4,
-                                               DataType::FP4,
-                                               DataType::FP4,
-                                               PointerType::Value,
-                                               1,
-                                               1,
-                                               4,
-                                               false,
-                                               false,
-                                               true>
+    struct ROCROLLER_DECLSPEC TypeInfo<FP4> : public BaseTypeInfo<FP4,
+                                                                  DataType::FP4,
+                                                                  DataType::FP4,
+                                                                  PointerType::Value,
+                                                                  1,
+                                                                  1,
+                                                                  4,
+                                                                  false,
+                                                                  false,
+                                                                  true>
     {
     };
 
-    struct FP4x8 : public DistinctType<uint32_t, FP4x8>
-    {
-    };
-
-    template <>
-    struct TypeInfo<FP4x8> : public BaseTypeInfo<FP4x8,
-                                                 DataType::FP4x8,
-                                                 DataType::FP4,
-                                                 PointerType::Value,
-                                                 8,
-                                                 1,
-                                                 32,
-                                                 false,
-                                                 false,
-                                                 false>
+    struct ROCROLLER_DECLSPEC FP4x8 : public DistinctType<uint32_t, FP4x8>
     {
     };
 
     template <>
-    struct TypeInfo<BFloat16> : public BaseTypeInfo<BFloat16,
-                                                    DataType::BFloat16,
-                                                    DataType::BFloat16,
-                                                    PointerType::Value,
-                                                    1,
-                                                    1,
-                                                    16,
-                                                    false,
-                                                    false,
-                                                    true>
-    {
-    };
-
-    struct BFloat16x2 : public DistinctType<uint32_t, BFloat16x2>
+    struct ROCROLLER_DECLSPEC TypeInfo<FP4x8> : public BaseTypeInfo<FP4x8,
+                                                                    DataType::FP4x8,
+                                                                    DataType::FP4,
+                                                                    PointerType::Value,
+                                                                    8,
+                                                                    1,
+                                                                    32,
+                                                                    false,
+                                                                    false,
+                                                                    false>
     {
     };
 
     template <>
-    struct TypeInfo<BFloat16x2> : public BaseTypeInfo<BFloat16x2,
-                                                      DataType::BFloat16x2,
-                                                      DataType::BFloat16,
-                                                      PointerType::Value,
-                                                      2,
-                                                      1,
-                                                      32,
-                                                      false,
-                                                      false,
-                                                      true>
+    struct ROCROLLER_DECLSPEC TypeInfo<BFloat16> : public BaseTypeInfo<BFloat16,
+                                                                       DataType::BFloat16,
+                                                                       DataType::BFloat16,
+                                                                       PointerType::Value,
+                                                                       1,
+                                                                       1,
+                                                                       16,
+                                                                       false,
+                                                                       false,
+                                                                       true>
     {
     };
 
-    struct Raw32 : public DistinctType<uint32_t, Raw32>
-    {
-    };
-
-    template <>
-    struct TypeInfo<Raw32> : public BaseTypeInfo<Raw32,
-                                                 DataType::Raw32,
-                                                 DataType::Raw32,
-                                                 PointerType::Value,
-                                                 1,
-                                                 1,
-                                                 32,
-                                                 false,
-                                                 true,
-                                                 false>
+    struct ROCROLLER_DECLSPEC BFloat16x2 : public DistinctType<uint32_t, BFloat16x2>
     {
     };
 
     template <>
-    struct TypeInfo<bool> : public BaseTypeInfo<bool,
-                                                DataType::Bool,
-                                                DataType::Bool,
-                                                PointerType::Value,
-                                                1,
-                                                1,
-                                                1,
-                                                false,
-                                                true,
-                                                false>
+    struct ROCROLLER_DECLSPEC TypeInfo<BFloat16x2> : public BaseTypeInfo<BFloat16x2,
+                                                                         DataType::BFloat16x2,
+                                                                         DataType::BFloat16,
+                                                                         PointerType::Value,
+                                                                         2,
+                                                                         1,
+                                                                         32,
+                                                                         false,
+                                                                         false,
+                                                                         true>
     {
     };
 
-    struct Bool32 : public DistinctType<uint32_t, Bool32>
-    {
-    };
-
-    template <>
-    struct TypeInfo<Bool32> : public BaseTypeInfo<Bool32,
-                                                  DataType::Bool32,
-                                                  DataType::Bool32,
-                                                  PointerType::Value,
-                                                  1,
-                                                  1,
-                                                  32,
-                                                  false,
-                                                  false,
-                                                  false>
-    {
-    };
-
-    struct Bool64 : public DistinctType<uint64_t, Bool64>
+    struct ROCROLLER_DECLSPEC Raw32 : public DistinctType<uint32_t, Raw32>
     {
     };
 
     template <>
-    struct TypeInfo<Bool64> : public BaseTypeInfo<Bool64,
-                                                  DataType::Bool64,
-                                                  DataType::Bool64,
-                                                  PointerType::Value,
-                                                  1,
-                                                  2,
-                                                  64,
-                                                  false,
-                                                  false,
-                                                  false>
-    {
-    };
-
-    struct PointerLocal : public DistinctType<uint32_t, PointerLocal>
+    struct ROCROLLER_DECLSPEC TypeInfo<Raw32> : public BaseTypeInfo<Raw32,
+                                                                    DataType::Raw32,
+                                                                    DataType::Raw32,
+                                                                    PointerType::Value,
+                                                                    1,
+                                                                    1,
+                                                                    32,
+                                                                    false,
+                                                                    true,
+                                                                    false>
     {
     };
 
     template <>
-    struct TypeInfo<PointerLocal> : public BaseTypeInfo<PointerLocal,
-                                                        DataType::None,
-                                                        DataType::None,
-                                                        PointerType::PointerLocal,
-                                                        1,
-                                                        1,
-                                                        32,
-                                                        false,
-                                                        true,
-                                                        false>
+    struct ROCROLLER_DECLSPEC TypeInfo<bool> : public BaseTypeInfo<bool,
+                                                                   DataType::Bool,
+                                                                   DataType::Bool,
+                                                                   PointerType::Value,
+                                                                   1,
+                                                                   1,
+                                                                   1,
+                                                                   false,
+                                                                   true,
+                                                                   false>
     {
     };
 
-    struct PointerGlobal : public DistinctType<uint64_t, PointerGlobal>
+    struct ROCROLLER_DECLSPEC Bool32 : public DistinctType<uint32_t, Bool32>
     {
     };
 
     template <>
-    struct TypeInfo<PointerGlobal> : public BaseTypeInfo<PointerGlobal,
-                                                         DataType::None,
-                                                         DataType::None,
-                                                         PointerType::PointerGlobal,
-                                                         1,
-                                                         2,
-                                                         64,
-                                                         false,
-                                                         true,
-                                                         false>
+    struct ROCROLLER_DECLSPEC TypeInfo<Bool32> : public BaseTypeInfo<Bool32,
+                                                                     DataType::Bool32,
+                                                                     DataType::Bool32,
+                                                                     PointerType::Value,
+                                                                     1,
+                                                                     1,
+                                                                     32,
+                                                                     false,
+                                                                     false,
+                                                                     false>
     {
     };
 
-    struct Buffer
+    struct ROCROLLER_DECLSPEC Bool64 : public DistinctType<uint64_t, Bool64>
+    {
+    };
+
+    template <>
+    struct ROCROLLER_DECLSPEC TypeInfo<Bool64> : public BaseTypeInfo<Bool64,
+                                                                     DataType::Bool64,
+                                                                     DataType::Bool64,
+                                                                     PointerType::Value,
+                                                                     1,
+                                                                     2,
+                                                                     64,
+                                                                     false,
+                                                                     false,
+                                                                     false>
+    {
+    };
+
+    struct ROCROLLER_DECLSPEC PointerLocal : public DistinctType<uint32_t, PointerLocal>
+    {
+    };
+
+    template <>
+    struct ROCROLLER_DECLSPEC TypeInfo<PointerLocal>
+        : public BaseTypeInfo<PointerLocal,
+                              DataType::None,
+                              DataType::None,
+                              PointerType::PointerLocal,
+                              1,
+                              1,
+                              32,
+                              false,
+                              true,
+                              false>
+    {
+    };
+
+    struct ROCROLLER_DECLSPEC PointerGlobal : public DistinctType<uint64_t, PointerGlobal>
+    {
+    };
+
+    template <>
+    struct ROCROLLER_DECLSPEC TypeInfo<PointerGlobal>
+        : public BaseTypeInfo<PointerGlobal,
+                              DataType::None,
+                              DataType::None,
+                              PointerType::PointerGlobal,
+                              1,
+                              2,
+                              64,
+                              false,
+                              true,
+                              false>
+    {
+    };
+
+    struct ROCROLLER_DECLSPEC Buffer
     {
         uint32_t desc0;
         uint32_t desc1;
@@ -1111,28 +1117,28 @@ namespace rocRoller
     };
 
     template <>
-    struct TypeInfo<Buffer> : public BaseTypeInfo<Buffer,
-                                                  DataType::None,
-                                                  DataType::None,
-                                                  PointerType::Buffer,
-                                                  1,
-                                                  4,
-                                                  128,
-                                                  false,
-                                                  true,
-                                                  false>
+    struct ROCROLLER_DECLSPEC TypeInfo<Buffer> : public BaseTypeInfo<Buffer,
+                                                                     DataType::None,
+                                                                     DataType::None,
+                                                                     PointerType::Buffer,
+                                                                     1,
+                                                                     4,
+                                                                     128,
+                                                                     false,
+                                                                     true,
+                                                                     false>
     {
     };
 
     template <DataType T_DataType>
-    struct EnumTypeInfo
+    struct ROCROLLER_DECLSPEC EnumTypeInfo
     {
     };
 
-#define DeclareEnumTypeInfo(typeEnum, dtype)                         \
-    template <>                                                      \
-    struct EnumTypeInfo<DataType::typeEnum> : public TypeInfo<dtype> \
-    {                                                                \
+#define DeclareEnumTypeInfo(typeEnum, dtype)                                            \
+    template <>                                                                         \
+    struct ROCROLLER_DECLSPEC EnumTypeInfo<DataType::typeEnum> : public TypeInfo<dtype> \
+    {                                                                                   \
     }
 
     DeclareEnumTypeInfo(Float, float);
@@ -1201,7 +1207,7 @@ namespace rocRoller
 namespace std
 {
     template <>
-    struct hash<rocRoller::VariableType>
+    struct ROCROLLER_DECLSPEC hash<rocRoller::VariableType>
     {
         inline size_t operator()(rocRoller::VariableType const& varType) const
         {

--- a/lib/include/rocRoller/DataTypes/DataTypes_BF16_Utils.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_BF16_Utils.hpp
@@ -35,6 +35,8 @@ j* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 namespace rocRoller
 {
 #pragma once
+
+#include <rocRoller/rocRoller.hpp>
     inline constexpr uint16_t BFLOAT16_Q_NAN_VALUE = 0xFFC1;
     inline constexpr uint16_t BFLOAT16_ZERO_VALUE  = 0x00;
 
@@ -85,7 +87,7 @@ namespace rocRoller
 
     }
 
-    struct BFloat16;
-    float    bf16_to_float(const BFloat16 v);
-    BFloat16 float_to_bf16(const float v);
+    struct ROCROLLER_DECLSPEC   BFloat16;
+    ROCROLLER_DECLSPEC float    bf16_to_float(const BFloat16 v);
+    ROCROLLER_DECLSPEC BFloat16 float_to_bf16(const float v);
 }

--- a/lib/include/rocRoller/DataTypes/DataTypes_BF6.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_BF6.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include "DataTypes_F6_Utils.hpp"
 #include <cinttypes>
 #include <cmath>
@@ -43,7 +45,7 @@ namespace rocRoller
      * \ingroup DataTypes
      * @{
      */
-    struct BF6
+    struct ROCROLLER_DECLSPEC BF6
     {
         constexpr BF6()
             : data(F6_ZERO_VALUE)
@@ -226,12 +228,12 @@ namespace std
     }
 
     template <>
-    struct is_floating_point<rocRoller::BF6> : true_type
+    struct ROCROLLER_DECLSPEC is_floating_point<rocRoller::BF6> : true_type
     {
     };
 
     template <>
-    struct hash<rocRoller::BF6>
+    struct ROCROLLER_DECLSPEC hash<rocRoller::BF6>
     {
         size_t operator()(const rocRoller::BF6& a) const
         {

--- a/lib/include/rocRoller/DataTypes/DataTypes_BF8.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_BF8.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <cinttypes>
 #include <cmath>
 #include <iostream>
@@ -48,7 +50,7 @@ namespace rocRoller
     *  @brief Floating point 8-bit type in E5M2 format
     *
     */
-    struct BF8
+    struct ROCROLLER_DECLSPEC BF8
     {
         constexpr BF8()
             : data(F8_ZERO_VALUE)
@@ -223,12 +225,12 @@ namespace std
     }
 
     template <>
-    struct is_floating_point<rocRoller::BF8> : true_type
+    struct ROCROLLER_DECLSPEC is_floating_point<rocRoller::BF8> : true_type
     {
     };
 
     template <>
-    struct hash<rocRoller::BF8>
+    struct ROCROLLER_DECLSPEC hash<rocRoller::BF8>
     {
         size_t operator()(const rocRoller::BF8& a) const
         {

--- a/lib/include/rocRoller/DataTypes/DataTypes_BFloat16.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_BFloat16.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/DataTypes/DataTypes_BF16_Utils.hpp>
 
 #define ROCROLLER_USE_BFloat16
@@ -40,7 +42,7 @@ namespace rocRoller
     *  @brief Floating point 8-bit type in E5M2 format
     *
     */
-    struct BFloat16
+    struct ROCROLLER_DECLSPEC BFloat16
     {
         constexpr BFloat16()
             : data(BFLOAT16_ZERO_VALUE)
@@ -101,12 +103,12 @@ namespace rocRoller
 namespace std
 {
     template <>
-    struct is_floating_point<rocRoller::BFloat16> : true_type
+    struct ROCROLLER_DECLSPEC is_floating_point<rocRoller::BFloat16> : true_type
     {
     };
 
     template <>
-    struct hash<rocRoller::BFloat16>
+    struct ROCROLLER_DECLSPEC hash<rocRoller::BFloat16>
     {
         size_t operator()(const rocRoller::BFloat16& a) const
         {

--- a/lib/include/rocRoller/DataTypes/DataTypes_F6_Utils.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_F6_Utils.hpp
@@ -26,6 +26,8 @@ j* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <cassert>
 #include <cinttypes>
 #include <cstdint>
@@ -346,11 +348,11 @@ namespace rocRoller
 
     inline constexpr int8_t F6_ZERO_VALUE = 0x0;
 
-    struct FP6;
-    float fp6_to_float(const FP6 v);
-    FP6   float_to_fp6(const float v);
+    struct ROCROLLER_DECLSPEC FP6;
+    ROCROLLER_DECLSPEC float  fp6_to_float(const FP6 v);
+    ROCROLLER_DECLSPEC FP6    float_to_fp6(const float v);
 
-    struct BF6;
-    float bf6_to_float(const BF6 v);
-    BF6   float_to_bf6(const float v);
+    struct ROCROLLER_DECLSPEC BF6;
+    ROCROLLER_DECLSPEC float  bf6_to_float(const BF6 v);
+    ROCROLLER_DECLSPEC BF6    float_to_bf6(const float v);
 }

--- a/lib/include/rocRoller/DataTypes/DataTypes_F8_Utils.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_F8_Utils.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/DataTypes/DataTypes_Half.hpp>
 #include <rocRoller/Utilities/Error.hpp>
 
@@ -415,13 +417,13 @@ namespace rocRoller
 
     inline constexpr int8_t F8_ZERO_VALUE = 0x0;
 
-    struct FP8;
-    float fp8_to_float(const FP8 v);
-    FP8   float_to_fp8(const float v);
+    struct ROCROLLER_DECLSPEC FP8;
+    ROCROLLER_DECLSPEC float  fp8_to_float(const FP8 v);
+    ROCROLLER_DECLSPEC FP8    float_to_fp8(const float v);
 
-    struct BF8;
-    float bf8_to_float(const BF8 v);
-    BF8   float_to_bf8(const float v);
+    struct ROCROLLER_DECLSPEC BF8;
+    ROCROLLER_DECLSPEC float  bf8_to_float(const BF8 v);
+    ROCROLLER_DECLSPEC BF8    float_to_bf8(const float v);
 
     inline float scaleToFloat(uint8_t scale)
     {
@@ -430,7 +432,7 @@ namespace rocRoller
 
     inline uint8_t floatToScale(float value)
     {
-        struct
+        struct ROCROLLER_DECLSPEC
         {
             uint mantissa : 23;
             uint exponent : 8;

--- a/lib/include/rocRoller/DataTypes/DataTypes_FP4.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_FP4.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <cinttypes>
 #include <cmath>
 #include <iostream>
@@ -38,7 +40,7 @@
 
 namespace rocRoller
 {
-    typedef struct
+    typedef struct ROCROLLER_DECLSPEC
     {
         uint32_t val : 4;
     } uint4_t;
@@ -330,7 +332,7 @@ namespace rocRoller
      * @{
      */
 
-    struct FP4
+    struct ROCROLLER_DECLSPEC FP4
     {
         constexpr FP4()
             : data(FP4_ZERO_VALUE)
@@ -531,12 +533,12 @@ namespace std
     }
 
     template <>
-    struct is_floating_point<rocRoller::FP4> : true_type
+    struct ROCROLLER_DECLSPEC is_floating_point<rocRoller::FP4> : true_type
     {
     };
 
     template <>
-    struct hash<rocRoller::FP4>
+    struct ROCROLLER_DECLSPEC hash<rocRoller::FP4>
     {
         size_t operator()(const rocRoller::FP4& a) const
         {

--- a/lib/include/rocRoller/DataTypes/DataTypes_FP6.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_FP6.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include "DataTypes_F6_Utils.hpp"
 #include <cassert>
 #include <cinttypes>
@@ -45,7 +47,7 @@ namespace rocRoller
      * \ingroup DataTypes
      * @{
      */
-    struct FP6
+    struct ROCROLLER_DECLSPEC FP6
     {
         constexpr FP6()
             : data(F6_ZERO_VALUE)
@@ -228,12 +230,12 @@ namespace std
     }
 
     template <>
-    struct is_floating_point<rocRoller::FP6> : true_type
+    struct ROCROLLER_DECLSPEC is_floating_point<rocRoller::FP6> : true_type
     {
     };
 
     template <>
-    struct hash<rocRoller::FP6>
+    struct ROCROLLER_DECLSPEC hash<rocRoller::FP6>
     {
         size_t operator()(const rocRoller::FP6& a) const
         {

--- a/lib/include/rocRoller/DataTypes/DataTypes_FP8.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_FP8.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/DataTypes/DataTypes_F8_Utils.hpp>
 
 #include <cinttypes>
@@ -48,7 +50,7 @@ namespace rocRoller
     *  @brief Floating point 8-bit type in E4M3 format
     *
     */
-    struct FP8
+    struct ROCROLLER_DECLSPEC FP8
     {
         constexpr FP8()
             : data(F8_ZERO_VALUE)
@@ -223,12 +225,12 @@ namespace std
     }
 
     template <>
-    struct is_floating_point<rocRoller::FP8> : true_type
+    struct ROCROLLER_DECLSPEC is_floating_point<rocRoller::FP8> : true_type
     {
     };
 
     template <>
-    struct hash<rocRoller::FP8>
+    struct ROCROLLER_DECLSPEC hash<rocRoller::FP8>
     {
         size_t operator()(const rocRoller::FP8& a) const
         {

--- a/lib/include/rocRoller/DataTypes/DataTypes_Half.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_Half.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #ifdef ROCROLLER_USE_HIP
 #include <hip/hip_fp16.h>
 #endif
@@ -47,7 +49,7 @@ namespace rocRoller
     /**
  * \ingroup DataTypes
  */
-    struct Half : public DistinctType<uint16_t, Half>
+    struct ROCROLLER_DECLSPEC Half : public DistinctType<uint16_t, Half>
     {
     };
 #endif
@@ -61,7 +63,7 @@ namespace std
     }
 
     template <>
-    struct hash<rocRoller::Half>
+    struct ROCROLLER_DECLSPEC hash<rocRoller::Half>
     {
         inline size_t operator()(rocRoller::Half const& h) const noexcept
         {
@@ -71,12 +73,12 @@ namespace std
     };
 
     template <>
-    struct is_floating_point<rocRoller::Half> : std::true_type
+    struct ROCROLLER_DECLSPEC is_floating_point<rocRoller::Half> : std::true_type
     {
     };
 
     template <>
-    struct is_signed<rocRoller::Half> : std::true_type
+    struct ROCROLLER_DECLSPEC is_signed<rocRoller::Half> : std::true_type
     {
     };
 } // namespace std

--- a/lib/include/rocRoller/DataTypes/DataTypes_Int8.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_Int8.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #ifdef ROCROLLER_USE_HIP
 #include <hip/hip_runtime.h>
 #endif
@@ -37,7 +39,7 @@ namespace rocRoller
     /**
  * \ingroup DataTypes
  */
-    struct Int8 : public DistinctType<int8_t, Int8>
+    struct ROCROLLER_DECLSPEC Int8 : public DistinctType<int8_t, Int8>
     {
     };
 } // namespace rocRoller

--- a/lib/include/rocRoller/DataTypes/DataTypes_Int8x4.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_Int8x4.hpp
@@ -26,11 +26,13 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <cstdint>
 
 namespace rocRoller
 {
-    struct Int8x4
+    struct ROCROLLER_DECLSPEC Int8x4
     {
         Int8x4()
             : a(0)

--- a/lib/include/rocRoller/DataTypes/DataTypes_UInt8x4.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_UInt8x4.hpp
@@ -26,11 +26,13 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <cstdint>
 
 namespace rocRoller
 {
-    struct UInt8x4
+    struct ROCROLLER_DECLSPEC UInt8x4
     {
         UInt8x4()
             : a(0)

--- a/lib/include/rocRoller/DataTypes/DataTypes_Utils.hpp
+++ b/lib/include/rocRoller/DataTypes/DataTypes_Utils.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <vector>
 
 #include <rocRoller/DataTypes/DataTypes.hpp>
@@ -33,76 +35,76 @@
 namespace rocRoller
 {
     template <typename T>
-    struct PackedTypeOf
+    struct ROCROLLER_DECLSPEC PackedTypeOf
     {
         typedef T type;
     };
 
     template <>
-    struct PackedTypeOf<FP6>
+    struct ROCROLLER_DECLSPEC PackedTypeOf<FP6>
     {
         typedef FP6x16 type;
     };
 
     template <>
-    struct PackedTypeOf<BF6>
+    struct ROCROLLER_DECLSPEC PackedTypeOf<BF6>
     {
         typedef BF6x16 type;
     };
 
     template <>
-    struct PackedTypeOf<FP4>
+    struct ROCROLLER_DECLSPEC PackedTypeOf<FP4>
     {
         typedef FP4x8 type;
     };
 
     template <typename T>
-    struct SegmentedTypeOf
+    struct ROCROLLER_DECLSPEC SegmentedTypeOf
     {
         typedef T type;
     };
 
     template <>
-    struct SegmentedTypeOf<FP6x16>
+    struct ROCROLLER_DECLSPEC SegmentedTypeOf<FP6x16>
     {
         typedef FP6 type;
     };
 
     template <>
-    struct SegmentedTypeOf<BF6x16>
+    struct ROCROLLER_DECLSPEC SegmentedTypeOf<BF6x16>
     {
         typedef BF6 type;
     };
 
     template <>
-    struct SegmentedTypeOf<FP4x8>
+    struct ROCROLLER_DECLSPEC SegmentedTypeOf<FP4x8>
     {
         typedef FP4 type;
     };
 
-    void                  packFP4x8(uint32_t* out, uint8_t const* data, size_t n);
-    std::vector<uint32_t> packFP4x8(std::vector<uint8_t> const&);
-    std::vector<uint8_t>  unpackFP4x8(std::vector<uint32_t> const&);
+    ROCROLLER_DECLSPEC void packFP4x8(uint32_t* out, uint8_t const* data, size_t n);
+    ROCROLLER_DECLSPEC std::vector<uint32_t> packFP4x8(std::vector<uint8_t> const&);
+    ROCROLLER_DECLSPEC std::vector<uint8_t> unpackFP4x8(std::vector<uint32_t> const&);
 
-    std::vector<uint32_t> f32_to_fp4x8(std::vector<float> f32);
-    std::vector<float>    fp4x8_to_f32(std::vector<uint32_t> f4x8);
+    ROCROLLER_DECLSPEC std::vector<uint32_t> f32_to_fp4x8(std::vector<float> f32);
+    ROCROLLER_DECLSPEC std::vector<float> fp4x8_to_f32(std::vector<uint32_t> f4x8);
 
-    void                  packF6x16(uint32_t*, uint8_t const*, size_t);
-    std::vector<uint32_t> packF6x16(std::vector<uint8_t> const&);
-    std::vector<uint8_t>  unpackF6x16(std::vector<uint32_t> const&);
+    ROCROLLER_DECLSPEC void packF6x16(uint32_t*, uint8_t const*, size_t);
+    ROCROLLER_DECLSPEC std::vector<uint32_t> packF6x16(std::vector<uint8_t> const&);
+    ROCROLLER_DECLSPEC std::vector<uint8_t> unpackF6x16(std::vector<uint32_t> const&);
 
     inline std::vector<float> unpackToFloat(std::vector<float> const& x)
     {
         return x;
     };
-    std::vector<float> unpackToFloat(std::vector<Half> const&);
-    std::vector<float> unpackToFloat(std::vector<Halfx2> const&);
-    std::vector<float> unpackToFloat(std::vector<BFloat16> const&);
-    std::vector<float> unpackToFloat(std::vector<FP8> const&);
-    std::vector<float> unpackToFloat(std::vector<BF8> const&);
-    std::vector<float> unpackToFloat(std::vector<FP8x4> const&);
-    std::vector<float> unpackToFloat(std::vector<BF8x4> const&);
-    std::vector<float> unpackToFloat(std::vector<FP6x16> const&);
-    std::vector<float> unpackToFloat(std::vector<BF6x16> const&);
-    std::vector<float> unpackToFloat(std::vector<FP4x8> const&);
+    ROCROLLER_DECLSPEC std::vector<float> unpackToFloat(std::vector<Half> const&);
+    ROCROLLER_DECLSPEC std::vector<float> unpackToFloat(std::vector<Halfx2> const&);
+    ROCROLLER_DECLSPEC std::vector<float> unpackToFloat(std::vector<BFloat16> const&);
+    ROCROLLER_DECLSPEC std::vector<float> unpackToFloat(std::vector<FP8> const&);
+    ROCROLLER_DECLSPEC std::vector<float> unpackToFloat(std::vector<BF8> const&);
+    ROCROLLER_DECLSPEC std::vector<float> unpackToFloat(std::vector<FP8x4> const&);
+    ROCROLLER_DECLSPEC std::vector<float> unpackToFloat(std::vector<BF8x4> const&);
+    ROCROLLER_DECLSPEC std::vector<float> unpackToFloat(std::vector<FP6x16> const&);
+    ROCROLLER_DECLSPEC std::vector<float> unpackToFloat(std::vector<BF6x16> const&);
+    ROCROLLER_DECLSPEC std::vector<float> unpackToFloat(std::vector<FP4x8> const&);
 }

--- a/lib/include/rocRoller/DataTypes/DistinctType.hpp
+++ b/lib/include/rocRoller/DataTypes/DistinctType.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <cstdlib>
 #include <iostream>
 #include <stdexcept>
@@ -45,7 +47,7 @@ namespace rocRoller
      * to its underlying data type.
      */
     template <typename T, typename Subclass>
-    struct DistinctType
+    struct ROCROLLER_DECLSPEC DistinctType
     {
         using Value = T;
 

--- a/lib/include/rocRoller/ExecutableKernel.hpp
+++ b/lib/include/rocRoller/ExecutableKernel.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/GPUArchitecture/GPUArchitectureTarget.hpp>
 #include <rocRoller/KernelArguments.hpp>
@@ -35,7 +37,7 @@ namespace rocRoller
 {
     // KernelInvocation contains the information needed to launch a kernel with
     // the ExecutableKernel class.
-    struct KernelInvocation
+    struct ROCROLLER_DECLSPEC KernelInvocation
     {
         std::array<unsigned int, 3> workitemCount  = {1, 1, 1};
         std::array<unsigned int, 3> workgroupSize  = {1, 1, 1};
@@ -44,7 +46,7 @@ namespace rocRoller
 
     // The executer class can load a kernel from a string of machine code and
     // then launch the kernel on a GPU.
-    class ExecutableKernel
+    class ROCROLLER_DECLSPEC ExecutableKernel
     {
     public:
         ExecutableKernel();
@@ -129,7 +131,7 @@ namespace rocRoller
         hipFunction_t getHipFunction() const;
 
     private:
-        struct HIPData;
+        struct ROCROLLER_DECLSPEC HIPData;
 
         std::string              m_kernelName;
         bool                     m_kernelLoaded;

--- a/lib/include/rocRoller/ExecutableKernel_fwd.hpp
+++ b/lib/include/rocRoller/ExecutableKernel_fwd.hpp
@@ -26,8 +26,10 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
-    struct KernelInvocation;
-    class ExecutableKernel;
+    struct ROCROLLER_DECLSPEC KernelInvocation;
+    class ROCROLLER_DECLSPEC  ExecutableKernel;
 }

--- a/lib/include/rocRoller/Expression.hpp
+++ b/lib/include/rocRoller/Expression.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <bitset>
 #include <memory>
 #include <stack>
@@ -41,8 +43,8 @@ namespace rocRoller
 {
     namespace Expression
     {
-        std::string   toString(EvaluationTime t);
-        std::ostream& operator<<(std::ostream&, EvaluationTime const&);
+        ROCROLLER_DECLSPEC std::string toString(EvaluationTime t);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, EvaluationTime const&);
 
         using EvaluationTimes = EnumBitset<EvaluationTime>;
 
@@ -52,8 +54,8 @@ namespace rocRoller
             Associative,
             Count
         };
-        std::string   toString(AlgebraicProperty t);
-        std::ostream& operator<<(std::ostream&, AlgebraicProperty const&);
+        ROCROLLER_DECLSPEC std::string toString(AlgebraicProperty t);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, AlgebraicProperty const&);
 
         using AlgebraicProperties = EnumBitset<AlgebraicProperty>;
 
@@ -66,13 +68,13 @@ namespace rocRoller
             Value,
             Count
         };
-        std::string   toString(Category c);
-        std::ostream& operator<<(std::ostream&, Category const&);
+        ROCROLLER_DECLSPEC std::string toString(Category c);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, Category const&);
 
         // Expression: type alias for std::variant of all expression subtypes.
         // Defined in Expression_fwd.hpp.
 
-        struct Binary
+        struct ROCROLLER_DECLSPEC Binary
         {
             ExpressionPtr lhs, rhs;
             std::string   comment = "";
@@ -95,7 +97,7 @@ namespace rocRoller
         // expressions. See the KernelOption minLaunchTimeExpressionComplexity for a more
         // in-depth description.
 
-        struct Add : Binary
+        struct ROCROLLER_DECLSPEC Add : Binary
         {
             constexpr static inline auto                Type      = Category::Arithmetic;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -104,7 +106,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 2;
         };
 
-        struct Subtract : Binary
+        struct ROCROLLER_DECLSPEC Subtract : Binary
         {
             constexpr static inline auto                Type      = Category::Arithmetic;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -112,7 +114,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 2;
         };
 
-        struct Multiply : Binary
+        struct ROCROLLER_DECLSPEC Multiply : Binary
         {
             constexpr static inline auto                Type      = Category::Arithmetic;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -121,7 +123,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 4;
         };
 
-        struct MultiplyHigh : Binary
+        struct ROCROLLER_DECLSPEC MultiplyHigh : Binary
         {
             constexpr static inline auto                Type      = Category::Arithmetic;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -129,7 +131,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 4;
         };
 
-        struct Divide : Binary
+        struct ROCROLLER_DECLSPEC Divide : Binary
         {
             constexpr static inline auto                Type      = Category::Arithmetic;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -137,7 +139,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 50;
         };
 
-        struct Modulo : Binary
+        struct ROCROLLER_DECLSPEC Modulo : Binary
         {
             constexpr static inline auto                Type      = Category::Arithmetic;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -145,7 +147,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 50;
         };
 
-        struct ShiftL : Binary
+        struct ROCROLLER_DECLSPEC ShiftL : Binary
         {
             constexpr static inline auto                Type      = Category::Arithmetic;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -153,7 +155,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 1;
         };
 
-        struct LogicalShiftR : Binary
+        struct ROCROLLER_DECLSPEC LogicalShiftR : Binary
         {
             constexpr static inline auto                Type      = Category::Arithmetic;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -161,7 +163,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 1;
         };
 
-        struct ArithmeticShiftR : Binary
+        struct ROCROLLER_DECLSPEC ArithmeticShiftR : Binary
         {
             constexpr static inline auto                Type      = Category::Arithmetic;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -169,16 +171,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 1;
         };
 
-        struct BitwiseAnd : Binary
-        {
-            constexpr static inline auto                Type      = Category::Arithmetic;
-            constexpr static inline auto                EvalTimes = EvaluationTimes::All();
-            constexpr static inline AlgebraicProperties Properties{AlgebraicProperty::Associative,
-                                                                   AlgebraicProperty::Commutative};
-            constexpr static inline int                 Complexity = 1;
-        };
-
-        struct BitwiseOr : Binary
+        struct ROCROLLER_DECLSPEC BitwiseAnd : Binary
         {
             constexpr static inline auto                Type      = Category::Arithmetic;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -187,7 +180,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 1;
         };
 
-        struct BitwiseXor : Binary
+        struct ROCROLLER_DECLSPEC BitwiseOr : Binary
         {
             constexpr static inline auto                Type      = Category::Arithmetic;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -196,7 +189,16 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 1;
         };
 
-        struct GreaterThan : Binary
+        struct ROCROLLER_DECLSPEC BitwiseXor : Binary
+        {
+            constexpr static inline auto                Type      = Category::Arithmetic;
+            constexpr static inline auto                EvalTimes = EvaluationTimes::All();
+            constexpr static inline AlgebraicProperties Properties{AlgebraicProperty::Associative,
+                                                                   AlgebraicProperty::Commutative};
+            constexpr static inline int                 Complexity = 1;
+        };
+
+        struct ROCROLLER_DECLSPEC GreaterThan : Binary
         {
             constexpr static inline auto                Type      = Category::Comparison;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -204,7 +206,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 2;
         };
 
-        struct GreaterThanEqual : Binary
+        struct ROCROLLER_DECLSPEC GreaterThanEqual : Binary
         {
             constexpr static inline auto                Type      = Category::Comparison;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -212,7 +214,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 2;
         };
 
-        struct LessThan : Binary
+        struct ROCROLLER_DECLSPEC LessThan : Binary
         {
             constexpr static inline auto                Type      = Category::Comparison;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -220,7 +222,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 2;
         };
 
-        struct LessThanEqual : Binary
+        struct ROCROLLER_DECLSPEC LessThanEqual : Binary
         {
             constexpr static inline auto                Type      = Category::Comparison;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -228,7 +230,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 2;
         };
 
-        struct Equal : Binary
+        struct ROCROLLER_DECLSPEC Equal : Binary
         {
             constexpr static inline auto                Type      = Category::Comparison;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -236,7 +238,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 2;
         };
 
-        struct NotEqual : Binary
+        struct ROCROLLER_DECLSPEC NotEqual : Binary
         {
             constexpr static inline auto                Type      = Category::Comparison;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -244,7 +246,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 1;
         };
 
-        struct LogicalAnd : Binary
+        struct ROCROLLER_DECLSPEC LogicalAnd : Binary
         {
             constexpr static inline auto                Type      = Category::Logical;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -253,7 +255,7 @@ namespace rocRoller
             constexpr static inline int                 Complexity = 1;
         };
 
-        struct LogicalOr : Binary
+        struct ROCROLLER_DECLSPEC LogicalOr : Binary
         {
             constexpr static inline auto                Type      = Category::Logical;
             constexpr static inline auto                EvalTimes = EvaluationTimes::All();
@@ -268,7 +270,7 @@ namespace rocRoller
          * for stochastic rounding.
          */
         template <DataType DATATYPE>
-        struct SRConvert : Binary
+        struct ROCROLLER_DECLSPEC SRConvert : Binary
         {
             constexpr static inline auto DestinationType = DATATYPE;
             constexpr static inline auto Type            = Category::Conversion;
@@ -276,7 +278,7 @@ namespace rocRoller
             constexpr static inline int  Complexity      = 2;
         };
 
-        struct Ternary
+        struct ROCROLLER_DECLSPEC Ternary
         {
             ExpressionPtr lhs, r1hs, r2hs;
             std::string   comment = "";
@@ -289,7 +291,7 @@ namespace rocRoller
             }
         };
 
-        struct TernaryMixed : Ternary
+        struct ROCROLLER_DECLSPEC TernaryMixed : Ternary
         {
         };
 
@@ -310,7 +312,7 @@ namespace rocRoller
          * ShiftL expression, lowering to the fused instruction if possible.
          * result = (lhs + r1hs) << r2hs
          */
-        struct AddShiftL : Ternary
+        struct ROCROLLER_DECLSPEC AddShiftL : Ternary
         {
             constexpr static inline auto            Type = Category::Arithmetic;
             constexpr static inline EvaluationTimes EvalTimes{EvaluationTime::KernelExecute};
@@ -322,7 +324,7 @@ namespace rocRoller
          * Add expression, lowering to the fused instruction if possible.
          * result = (lhs << r1hs) + r2hs
          */
-        struct ShiftLAdd : Ternary
+        struct ROCROLLER_DECLSPEC ShiftLAdd : Ternary
         {
             constexpr static inline auto            Type = Category::Arithmetic;
             constexpr static inline EvaluationTimes EvalTimes{EvaluationTime::KernelExecute};
@@ -334,7 +336,7 @@ namespace rocRoller
          *
          * MatA is M x K, with B batches.  MatB is K x N, with B batches.  MatC is M x N, with B batches.
          */
-        struct MatrixMultiply : Ternary
+        struct ROCROLLER_DECLSPEC MatrixMultiply : Ternary
         {
             MatrixMultiply() = default;
 
@@ -357,7 +359,7 @@ namespace rocRoller
             constexpr static inline int             Complexity = 20;
         };
 
-        struct ScaledMatrixMultiply
+        struct ROCROLLER_DECLSPEC ScaledMatrixMultiply
         {
             ExpressionPtr matA, matB, matC, scaleA, scaleB;
             DataType      accumulationPrecision = DataType::Float;
@@ -386,7 +388,7 @@ namespace rocRoller
          * Represents DEST = LHS ? R1HS : R2HS.
          * Utilizes cselect
         */
-        struct Conditional : Ternary
+        struct ROCROLLER_DECLSPEC Conditional : Ternary
         {
             constexpr static inline auto Type       = Category::Arithmetic;
             constexpr static inline auto EvalTimes  = EvaluationTimes::All();
@@ -398,7 +400,7 @@ namespace rocRoller
          * Utilizes TernaryMixed instead of Ternary
          * allows for mixed precision arithmetic
          */
-        struct MultiplyAdd : TernaryMixed
+        struct ROCROLLER_DECLSPEC MultiplyAdd : TernaryMixed
         {
             constexpr static inline auto Type        = Category::Arithmetic;
             constexpr static inline auto EvalTimes   = EvaluationTimes::All();
@@ -407,7 +409,7 @@ namespace rocRoller
             constexpr static inline int  Complexity  = 4;
         };
 
-        struct Unary
+        struct ROCROLLER_DECLSPEC Unary
         {
             ExpressionPtr arg;
             std::string   comment = "";
@@ -426,7 +428,7 @@ namespace rocRoller
             requires std::derived_from<T, Unary>;
         };
 
-        struct MagicMultiple : Unary
+        struct ROCROLLER_DECLSPEC MagicMultiple : Unary
         {
             constexpr static inline auto            Type = Category::Arithmetic;
             constexpr static inline EvaluationTimes EvalTimes{EvaluationTime::Translate,
@@ -434,7 +436,7 @@ namespace rocRoller
             constexpr static inline int             Complexity = 50;
         };
 
-        struct MagicShifts : Unary
+        struct ROCROLLER_DECLSPEC MagicShifts : Unary
         {
             constexpr static inline auto            Type = Category::Arithmetic;
             constexpr static inline EvaluationTimes EvalTimes{EvaluationTime::Translate,
@@ -442,7 +444,7 @@ namespace rocRoller
             constexpr static inline int             Complexity = 50;
         };
 
-        struct MagicSign : Unary
+        struct ROCROLLER_DECLSPEC MagicSign : Unary
         {
             constexpr static inline auto            Type = Category::Arithmetic;
             constexpr static inline EvaluationTimes EvalTimes{EvaluationTime::Translate,
@@ -450,21 +452,21 @@ namespace rocRoller
             constexpr static inline int             Complexity = 50;
         };
 
-        struct Negate : Unary
+        struct ROCROLLER_DECLSPEC Negate : Unary
         {
             constexpr static inline auto Type       = Category::Arithmetic;
             constexpr static inline auto EvalTimes  = EvaluationTimes::All();
             constexpr static inline int  Complexity = 1;
         };
 
-        struct BitwiseNegate : Unary
+        struct ROCROLLER_DECLSPEC BitwiseNegate : Unary
         {
             constexpr static inline auto Type       = Category::Arithmetic;
             constexpr static inline auto EvalTimes  = EvaluationTimes::All();
             constexpr static inline int  Complexity = 1;
         };
 
-        struct Convert : Unary
+        struct ROCROLLER_DECLSPEC Convert : Unary
         {
             inline Convert& copyParams(const Convert& other)
             {
@@ -480,21 +482,21 @@ namespace rocRoller
             DataType destinationType = DataType::None;
         };
 
-        struct LogicalNot : Unary
+        struct ROCROLLER_DECLSPEC LogicalNot : Unary
         {
             constexpr static inline auto Type       = Category::Logical;
             constexpr static inline auto EvalTimes  = EvaluationTimes::All();
             constexpr static inline int  Complexity = 1;
         };
 
-        struct Exponential2 : Unary
+        struct ROCROLLER_DECLSPEC Exponential2 : Unary
         {
             constexpr static inline auto Type       = Category::Arithmetic;
             constexpr static inline auto EvalTimes  = EvaluationTimes::All();
             constexpr static inline int  Complexity = 1;
         };
 
-        struct Exponential : Unary
+        struct ROCROLLER_DECLSPEC Exponential : Unary
         {
             constexpr static inline auto            Type = Category::Arithmetic;
             constexpr static inline EvaluationTimes EvalTimes{EvaluationTime::Translate,
@@ -502,14 +504,14 @@ namespace rocRoller
             constexpr static inline int             Complexity = 2;
         };
 
-        struct RandomNumber : Unary
+        struct ROCROLLER_DECLSPEC RandomNumber : Unary
         {
             constexpr static inline auto Type       = Category::Arithmetic;
             constexpr static inline auto EvalTimes  = EvaluationTimes::All();
             constexpr static inline int  Complexity = 1;
         };
 
-        struct BitFieldExtract : Unary
+        struct ROCROLLER_DECLSPEC BitFieldExtract : Unary
         {
             inline BitFieldExtract& copyParams(const BitFieldExtract& other)
             {
@@ -539,7 +541,7 @@ namespace rocRoller
          * If `varType` is `DataType::None`, the data type is
          * "deferred".
          */
-        struct DataFlowTag
+        struct ROCROLLER_DECLSPEC DataFlowTag
         {
             int tag;
 
@@ -729,105 +731,113 @@ namespace rocRoller
         // Other visitors
         //
 
-        std::string   toString(ExpressionPtr const& expr);
-        std::string   toString(Expression const& expr);
-        std::ostream& operator<<(std::ostream&, ExpressionPtr const&);
-        std::ostream& operator<<(std::ostream&, Expression const&);
-        std::ostream& operator<<(std::ostream&, std::vector<ExpressionPtr> const&);
+        ROCROLLER_DECLSPEC std::string toString(ExpressionPtr const& expr);
+        ROCROLLER_DECLSPEC std::string toString(Expression const& expr);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, ExpressionPtr const&);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, Expression const&);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&,
+                                                    std::vector<ExpressionPtr> const&);
 
-        std::string name(ExpressionPtr const& expr);
-        std::string name(Expression const& expr);
+        ROCROLLER_DECLSPEC std::string name(ExpressionPtr const& expr);
+        ROCROLLER_DECLSPEC std::string name(Expression const& expr);
 
-        std::string argumentName(ExpressionPtr const& expr);
-        std::string argumentName(Expression const& expr);
+        ROCROLLER_DECLSPEC std::string argumentName(ExpressionPtr const& expr);
+        ROCROLLER_DECLSPEC std::string argumentName(Expression const& expr);
 
         // EvaluationTime max(EvaluationTime lhs, EvaluationTime rhs);
 
-        EvaluationTimes evaluationTimes(ExpressionPtr const& expr);
-        EvaluationTimes evaluationTimes(Expression const& expr);
+        ROCROLLER_DECLSPEC EvaluationTimes evaluationTimes(ExpressionPtr const& expr);
+        ROCROLLER_DECLSPEC EvaluationTimes evaluationTimes(Expression const& expr);
 
-        VariableType resultVariableType(Expression const& expr);
-        VariableType resultVariableType(ExpressionPtr const& expr);
+        ROCROLLER_DECLSPEC VariableType resultVariableType(Expression const& expr);
+        ROCROLLER_DECLSPEC VariableType resultVariableType(ExpressionPtr const& expr);
 
-        Register::Type resultRegisterType(Expression const& expr);
-        Register::Type resultRegisterType(ExpressionPtr const& expr);
+        ROCROLLER_DECLSPEC Register::Type resultRegisterType(Expression const& expr);
+        ROCROLLER_DECLSPEC Register::Type resultRegisterType(ExpressionPtr const& expr);
 
-        struct ResultType
+        struct ROCROLLER_DECLSPEC ResultType
         {
             Register::Type regType;
             VariableType   varType;
             bool           operator==(ResultType const&) const = default;
         };
-        ResultType resultType(ExpressionPtr const& expr);
-        ResultType resultType(Expression const& expr);
+        ROCROLLER_DECLSPEC ResultType resultType(ExpressionPtr const& expr);
+        ROCROLLER_DECLSPEC ResultType resultType(Expression const& expr);
 
-        std::string   toString(ResultType const& obj);
-        std::ostream& operator<<(std::ostream&, ResultType const&);
+        ROCROLLER_DECLSPEC std::string toString(ResultType const& obj);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, ResultType const&);
 
         /**
          * True when two expressions are identical.
          *
          * NOTE: Never considers commutativity or associativity.
          */
-        bool identical(ExpressionPtr const&, ExpressionPtr const&);
-        bool identical(Expression const&, Expression const&);
+        ROCROLLER_DECLSPEC bool identical(ExpressionPtr const&, ExpressionPtr const&);
+        ROCROLLER_DECLSPEC bool identical(Expression const&, Expression const&);
 
         /**
          * True when two expressions are equivalent.
          * Optionally considers algebraic properties like commutativity.
          */
-        bool equivalent(ExpressionPtr const&,
-                        ExpressionPtr const&,
-                        AlgebraicProperties = AlgebraicProperties::All());
+        ROCROLLER_DECLSPEC bool equivalent(ExpressionPtr const&,
+                                           ExpressionPtr const&,
+                                           AlgebraicProperties = AlgebraicProperties::All());
 
         /**
          * Comment accessors.
          */
-        void setComment(ExpressionPtr& expr, std::string comment);
-        void setComment(Expression& expr, std::string comment);
+        ROCROLLER_DECLSPEC void setComment(ExpressionPtr& expr, std::string comment);
+        ROCROLLER_DECLSPEC void setComment(Expression& expr, std::string comment);
 
-        std::string getComment(Expression const& expr, bool includeRegisterComments);
-        std::string getComment(ExpressionPtr const& expr, bool includeRegisterComments);
+        ROCROLLER_DECLSPEC std::string getComment(Expression const& expr,
+                                                  bool              includeRegisterComments);
+        ROCROLLER_DECLSPEC std::string getComment(ExpressionPtr const& expr,
+                                                  bool                 includeRegisterComments);
 
-        std::string getComment(ExpressionPtr const& expr);
-        std::string getComment(Expression const& expr);
-        std::string getComment(ExpressionPtr const& expr, bool includeRegisterComments);
-        std::string getComment(Expression const& expr, bool includeRegisterComments);
+        ROCROLLER_DECLSPEC std::string getComment(ExpressionPtr const& expr);
+        ROCROLLER_DECLSPEC std::string getComment(Expression const& expr);
+        ROCROLLER_DECLSPEC std::string getComment(ExpressionPtr const& expr,
+                                                  bool                 includeRegisterComments);
+        ROCROLLER_DECLSPEC std::string getComment(Expression const& expr,
+                                                  bool              includeRegisterComments);
 
         /**
          * Copies any comments from src into dst.  If dst is not of a type that allows
          * comments, does nothing.
          */
-        void copyComment(ExpressionPtr const& dst, ExpressionPtr const& src);
-        void copyComment(Expression& dst, ExpressionPtr const& src);
-        void copyComment(ExpressionPtr const& dst, Expression const& src);
-        void copyComment(Expression& dst, Expression const& src);
+        ROCROLLER_DECLSPEC void copyComment(ExpressionPtr const& dst, ExpressionPtr const& src);
+        ROCROLLER_DECLSPEC void copyComment(Expression& dst, ExpressionPtr const& src);
+        ROCROLLER_DECLSPEC void copyComment(ExpressionPtr const& dst, Expression const& src);
+        ROCROLLER_DECLSPEC void copyComment(Expression& dst, Expression const& src);
 
-        void appendComment(ExpressionPtr& expr, std::string comment);
-        void appendComment(Expression& expr, std::string comment);
+        ROCROLLER_DECLSPEC void appendComment(ExpressionPtr& expr, std::string comment);
+        ROCROLLER_DECLSPEC void appendComment(Expression& expr, std::string comment);
 
         /**
          * Evaluate an expression whose evaluationTime is Translate.  Will throw an exception
          * otherwise.
          */
-        CommandArgumentValue evaluate(ExpressionPtr const& expr);
-        CommandArgumentValue evaluate(Expression const& expr);
+        ROCROLLER_DECLSPEC CommandArgumentValue evaluate(ExpressionPtr const& expr);
+        ROCROLLER_DECLSPEC CommandArgumentValue evaluate(Expression const& expr);
 
         /**
          * Evaluate an expression if its evaluationTime is Translate, returns nullopt
          * otherwise.
          */
-        std::optional<CommandArgumentValue> tryEvaluate(ExpressionPtr const& expr);
-        std::optional<CommandArgumentValue> tryEvaluate(Expression const& expr);
+        ROCROLLER_DECLSPEC std::optional<CommandArgumentValue>
+                           tryEvaluate(ExpressionPtr const& expr);
+        ROCROLLER_DECLSPEC std::optional<CommandArgumentValue> tryEvaluate(Expression const& expr);
 
-        bool canEvaluateTo(CommandArgumentValue val, ExpressionPtr const& expr);
+        ROCROLLER_DECLSPEC bool canEvaluateTo(CommandArgumentValue val, ExpressionPtr const& expr);
 
         /**
          * Evaluate an expression whose evaluationTime is Translate or KernelLaunch.  Will throw
          * an exception if it contains any Register values.
          */
-        CommandArgumentValue evaluate(ExpressionPtr const& expr, RuntimeArguments const& args);
-        CommandArgumentValue evaluate(Expression const& expr, RuntimeArguments const& args);
+        ROCROLLER_DECLSPEC CommandArgumentValue evaluate(ExpressionPtr const&    expr,
+                                                         RuntimeArguments const& args);
+        ROCROLLER_DECLSPEC CommandArgumentValue evaluate(Expression const&       expr,
+                                                         RuntimeArguments const& args);
 
         /**
          * Splits an expression and returns its operands in a tuple.
@@ -840,39 +850,42 @@ namespace rocRoller
          * Throws if expr is not of type Expr.
          */
         template <typename Expr>
-        requires(CUnary<Expr> || CBinary<Expr> || CTernary<Expr>) auto split(ExpressionPtr expr);
+        requires(CUnary<Expr> || CBinary<Expr> || CTernary<Expr>) ROCROLLER_DECLSPEC
+            auto split(ExpressionPtr expr);
 
         /**
          * Returns an approximate total complexity for an expression, to be used as a heuristic.
          * See the KernelOption minLaunchTimeExpressionComplexity for a more in-depth
          * description.
          */
-        int complexity(ExpressionPtr expr);
-        int complexity(Expression const& expr);
+        ROCROLLER_DECLSPEC int complexity(ExpressionPtr expr);
+        ROCROLLER_DECLSPEC int complexity(Expression const& expr);
 
-        Generator<Instruction>
+        ROCROLLER_DECLSPEC Generator<Instruction>
             generate(Register::ValuePtr& dest, ExpressionPtr expr, ContextPtr context);
 
-        std::string   toYAML(ExpressionPtr const& expr);
-        ExpressionPtr fromYAML(std::string const& str);
+        ROCROLLER_DECLSPEC std::string   toYAML(ExpressionPtr const& expr);
+        ROCROLLER_DECLSPEC ExpressionPtr fromYAML(std::string const& str);
 
         /**
          * Returns true if expr is of type T or if expr contains a subexpression of type T.
          */
         template <CExpression T>
-        bool contains(ExpressionPtr expr);
+        ROCROLLER_DECLSPEC bool contains(ExpressionPtr expr);
 
         /**
          * Returns true if expr is of type T or if expr contains a subexpression of type T.
          */
         template <CExpression T>
-        bool contains(Expression const& expr);
+        ROCROLLER_DECLSPEC bool contains(Expression const& expr);
 
         /**
          * Returns true if expr contains a sub-expression
          */
-        bool containsSubExpression(ExpressionPtr const& expr, ExpressionPtr const& subExpr);
-        bool containsSubExpression(Expression const& expr, Expression const& subExpr);
+        ROCROLLER_DECLSPEC bool containsSubExpression(ExpressionPtr const& expr,
+                                                      ExpressionPtr const& subExpr);
+        ROCROLLER_DECLSPEC bool containsSubExpression(Expression const& expr,
+                                                      Expression const& subExpr);
 
     } // namespace Expression
 } // namespace rocRoller

--- a/lib/include/rocRoller/ExpressionTransformations.hpp
+++ b/lib/include/rocRoller/ExpressionTransformations.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/Expression_fwd.hpp>
 
@@ -33,14 +35,15 @@ namespace rocRoller
 {
     namespace Expression
     {
-        ExpressionPtr identity(ExpressionPtr expr);
+        ROCROLLER_DECLSPEC ExpressionPtr identity(ExpressionPtr expr);
 
         /**
          * Transform sub-expressions of `expr` into new kernel arguments
          *
          * Return value should be Translate time or KernelExecute time evaluable.
          */
-        ExpressionPtr launchTimeSubExpressions(ExpressionPtr expr, ContextPtr context);
+        ROCROLLER_DECLSPEC ExpressionPtr launchTimeSubExpressions(ExpressionPtr expr,
+                                                                  ContextPtr    context);
 
         /**
          * Restore any command arguments that have been cleaned (transformed from command
@@ -48,7 +51,7 @@ namespace rocRoller
          *
          * Return value should be Translate time or KernelLaunch time evaluable.
          */
-        ExpressionPtr restoreCommandArguments(ExpressionPtr expr);
+        ROCROLLER_DECLSPEC ExpressionPtr restoreCommandArguments(ExpressionPtr expr);
 
         /**
          * @brief Attempt to replace division operations found within an expression with faster operations.
@@ -57,14 +60,14 @@ namespace rocRoller
          * @param context
          * @return ExpressionPtr Transformed expression
          */
-        ExpressionPtr fastDivision(ExpressionPtr expr, ContextPtr context);
+        ROCROLLER_DECLSPEC ExpressionPtr fastDivision(ExpressionPtr expr, ContextPtr context);
 
         /**
          * Ensures that the kernel arguments will include the magic constants required to divide/modulo
          * by `expr`.
          * Requires `expr` to have a type of either Int32 or Int64, and to be evaluable at kernel launch time.
          */
-        void enableDivideBy(ExpressionPtr expr, ContextPtr context);
+        ROCROLLER_DECLSPEC void enableDivideBy(ExpressionPtr expr, ContextPtr context);
 
         /**
          * @brief Attempt to replace multiplication operations found within an expression with faster operations.
@@ -72,13 +75,13 @@ namespace rocRoller
          * @param expr Input expression
          * @return ExpressionPtr Transformed expression
          */
-        ExpressionPtr fastMultiplication(ExpressionPtr expr);
+        ROCROLLER_DECLSPEC ExpressionPtr fastMultiplication(ExpressionPtr expr);
 
         /**
          * Attempt to combine multiple shifts:
          * - Opposite shifts by same amount: mask off bits that would be zeroed out.
          */
-        ExpressionPtr combineShifts(ExpressionPtr expr);
+        ROCROLLER_DECLSPEC ExpressionPtr combineShifts(ExpressionPtr expr);
 
         /**
          * @brief Simplify expressions
@@ -86,7 +89,7 @@ namespace rocRoller
          * @param expr Input expression
          * @return ExpressionPtr Transformed expression
          */
-        ExpressionPtr simplify(ExpressionPtr expr);
+        ROCROLLER_DECLSPEC ExpressionPtr simplify(ExpressionPtr expr);
 
         /**
          * @brief Fuse binary expressions into ternaries.
@@ -94,7 +97,7 @@ namespace rocRoller
          * @param expr Input expression
          * @return ExpressionPtr Transformed expression
          */
-        ExpressionPtr fuseTernary(ExpressionPtr expr);
+        ROCROLLER_DECLSPEC ExpressionPtr fuseTernary(ExpressionPtr expr);
 
         /**
          * @brief Fuse binary expressions if one combination is able to be condensed by association
@@ -102,7 +105,7 @@ namespace rocRoller
          * @param expr Input expression
          * @return ExpressionPtr Transformed expression
          */
-        ExpressionPtr fuseAssociative(ExpressionPtr expr);
+        ROCROLLER_DECLSPEC ExpressionPtr fuseAssociative(ExpressionPtr expr);
 
         /**
          * Resolve all DataFlowTags in the given expression.
@@ -111,7 +114,8 @@ namespace rocRoller
          * @param expr Input expression
          * @return ExpressionPtr Transformed expression
          */
-        ExpressionPtr dataFlowTagPropagation(ExpressionPtr expr, ContextPtr context);
+        ROCROLLER_DECLSPEC ExpressionPtr dataFlowTagPropagation(ExpressionPtr expr,
+                                                                ContextPtr    context);
 
         /**
          * @brief Attempt to compute e^x operations by using exp2(x * log2(e)).
@@ -119,7 +123,7 @@ namespace rocRoller
          * @param expr Input expression
          * @return ExpressionPtr Transformed expression
          */
-        ExpressionPtr lowerExponential(ExpressionPtr expr);
+        ROCROLLER_DECLSPEC ExpressionPtr lowerExponential(ExpressionPtr expr);
 
         /**
          * Helper (lambda/transducer) for applying all fast arithmetic transformations.
@@ -131,7 +135,7 @@ namespace rocRoller
          *
          * Can also be passed as an ExpressionTransducer.
          */
-        struct FastArithmetic
+        struct ROCROLLER_DECLSPEC FastArithmetic
         {
             FastArithmetic() = delete;
             explicit FastArithmetic(ContextPtr);
@@ -151,7 +155,7 @@ namespace rocRoller
          * @param context
          * @return ExpressionPtr Transformed expression
          */
-        ExpressionPtr lowerPRNG(ExpressionPtr exp, ContextPtr context);
+        ROCROLLER_DECLSPEC ExpressionPtr lowerPRNG(ExpressionPtr exp, ContextPtr context);
 
         /**
          * @brief Resolve all ValuePtr expressions that are bitfields into
@@ -160,6 +164,6 @@ namespace rocRoller
          * @param expr Input expression
          * @return ExpressionPtr Transformed expression
          */
-        ExpressionPtr lowerBitfieldValues(ExpressionPtr expr);
+        ROCROLLER_DECLSPEC ExpressionPtr lowerBitfieldValues(ExpressionPtr expr);
     }
 }

--- a/lib/include/rocRoller/Expression_fwd.hpp
+++ b/lib/include/rocRoller/Expression_fwd.hpp
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <functional>
 #include <memory>
@@ -44,54 +46,54 @@ namespace rocRoller
 {
     namespace Expression
     {
-        struct Add;
-        struct MatrixMultiply;
-        struct ScaledMatrixMultiply;
-        struct Multiply;
-        struct MultiplyAdd;
-        struct MultiplyHigh;
-        struct Subtract;
-        struct Divide;
-        struct Modulo;
-        struct ShiftL;
-        struct LogicalShiftR;
-        struct ArithmeticShiftR;
-        struct BitwiseNegate;
-        struct BitwiseAnd;
-        struct BitwiseOr;
-        struct BitwiseXor;
-        struct GreaterThan;
-        struct GreaterThanEqual;
-        struct LessThan;
-        struct LessThanEqual;
-        struct Equal;
-        struct NotEqual;
-        struct LogicalAnd;
-        struct LogicalOr;
-        struct LogicalNot;
+        struct ROCROLLER_DECLSPEC Add;
+        struct ROCROLLER_DECLSPEC MatrixMultiply;
+        struct ROCROLLER_DECLSPEC ScaledMatrixMultiply;
+        struct ROCROLLER_DECLSPEC Multiply;
+        struct ROCROLLER_DECLSPEC MultiplyAdd;
+        struct ROCROLLER_DECLSPEC MultiplyHigh;
+        struct ROCROLLER_DECLSPEC Subtract;
+        struct ROCROLLER_DECLSPEC Divide;
+        struct ROCROLLER_DECLSPEC Modulo;
+        struct ROCROLLER_DECLSPEC ShiftL;
+        struct ROCROLLER_DECLSPEC LogicalShiftR;
+        struct ROCROLLER_DECLSPEC ArithmeticShiftR;
+        struct ROCROLLER_DECLSPEC BitwiseNegate;
+        struct ROCROLLER_DECLSPEC BitwiseAnd;
+        struct ROCROLLER_DECLSPEC BitwiseOr;
+        struct ROCROLLER_DECLSPEC BitwiseXor;
+        struct ROCROLLER_DECLSPEC GreaterThan;
+        struct ROCROLLER_DECLSPEC GreaterThanEqual;
+        struct ROCROLLER_DECLSPEC LessThan;
+        struct ROCROLLER_DECLSPEC LessThanEqual;
+        struct ROCROLLER_DECLSPEC Equal;
+        struct ROCROLLER_DECLSPEC NotEqual;
+        struct ROCROLLER_DECLSPEC LogicalAnd;
+        struct ROCROLLER_DECLSPEC LogicalOr;
+        struct ROCROLLER_DECLSPEC LogicalNot;
 
-        struct Exponential2;
-        struct Exponential;
+        struct ROCROLLER_DECLSPEC Exponential2;
+        struct ROCROLLER_DECLSPEC Exponential;
 
-        struct MagicMultiple;
-        struct MagicShifts;
-        struct MagicSign;
-        struct Negate;
+        struct ROCROLLER_DECLSPEC MagicMultiple;
+        struct ROCROLLER_DECLSPEC MagicShifts;
+        struct ROCROLLER_DECLSPEC MagicSign;
+        struct ROCROLLER_DECLSPEC Negate;
 
-        struct RandomNumber;
+        struct ROCROLLER_DECLSPEC RandomNumber;
 
-        struct BitFieldExtract;
+        struct ROCROLLER_DECLSPEC BitFieldExtract;
 
-        struct AddShiftL;
-        struct ShiftLAdd;
-        struct Conditional;
+        struct ROCROLLER_DECLSPEC AddShiftL;
+        struct ROCROLLER_DECLSPEC ShiftLAdd;
+        struct ROCROLLER_DECLSPEC Conditional;
 
-        struct Convert;
+        struct ROCROLLER_DECLSPEC Convert;
 
         template <DataType DATATYPE>
-        struct SRConvert;
+        struct ROCROLLER_DECLSPEC SRConvert;
 
-        struct DataFlowTag;
+        struct ROCROLLER_DECLSPEC DataFlowTag;
         using WaveTilePtr = std::shared_ptr<KernelGraph::CoordinateGraph::WaveTile>;
 
         using Expression = std::variant<

--- a/lib/include/rocRoller/GPUArchitecture/GPUArchitecture.hpp
+++ b/lib/include/rocRoller/GPUArchitecture/GPUArchitecture.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <array>
 #include <cstdio>
 #include <fstream>
@@ -45,7 +47,7 @@
 
 namespace rocRoller
 {
-    class GPUArchitecture
+    class ROCROLLER_DECLSPEC GPUArchitecture
     {
     public:
         GPUArchitecture();
@@ -121,7 +123,7 @@ namespace rocRoller
     };
 
     //Used as a container for serialization.
-    struct GPUArchitecturesStruct
+    struct ROCROLLER_DECLSPEC GPUArchitecturesStruct
     {
         std::map<GPUArchitectureTarget, GPUArchitecture> architectures;
     };

--- a/lib/include/rocRoller/GPUArchitecture/GPUArchitectureLibrary.hpp
+++ b/lib/include/rocRoller/GPUArchitecture/GPUArchitectureLibrary.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <array>
 #include <cstdio>
 #include <fstream>
@@ -46,7 +48,7 @@
 
 namespace rocRoller
 {
-    class GPUArchitectureLibrary : public LazySingleton<GPUArchitectureLibrary>
+    class ROCROLLER_DECLSPEC GPUArchitectureLibrary : public LazySingleton<GPUArchitectureLibrary>
     {
     public:
         bool               HasCapability(GPUArchitectureTarget const&, GPUCapability const&);

--- a/lib/include/rocRoller/GPUArchitecture/GPUArchitectureLibrary_impl.hpp
+++ b/lib/include/rocRoller/GPUArchitecture/GPUArchitectureLibrary_impl.hpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <array>
 #include <cstdio>
 #include <filesystem>

--- a/lib/include/rocRoller/GPUArchitecture/GPUArchitectureTarget.hpp
+++ b/lib/include/rocRoller/GPUArchitecture/GPUArchitectureTarget.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <array>
 #include <cstdio>
 #include <fstream>
@@ -70,12 +72,12 @@ namespace rocRoller
 
         Count,
     };
-    std::string toString(GPUArchitectureGFX const& gfx);
-    std::string name(GPUArchitectureGFX const& gfx);
+    ROCROLLER_DECLSPEC std::string toString(GPUArchitectureGFX const& gfx);
+    ROCROLLER_DECLSPEC std::string name(GPUArchitectureGFX const& gfx);
 
-    std::ostream& operator<<(std::ostream&, GPUArchitectureGFX const& gfx);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, GPUArchitectureGFX const& gfx);
 
-    struct GPUArchitectureFeatures
+    struct ROCROLLER_DECLSPEC GPUArchitectureFeatures
     {
     public:
         bool sramecc = false;
@@ -91,7 +93,7 @@ namespace rocRoller
         auto operator<=>(const GPUArchitectureFeatures&) const = default;
     };
 
-    struct GPUArchitectureTarget
+    struct ROCROLLER_DECLSPEC GPUArchitectureTarget
     {
     public:
         GPUArchitectureGFX      gfx      = GPUArchitectureGFX::UNKNOWN;

--- a/lib/include/rocRoller/GPUArchitecture/GPUArchitectureTarget_fwd.hpp
+++ b/lib/include/rocRoller/GPUArchitecture/GPUArchitectureTarget_fwd.hpp
@@ -26,7 +26,9 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
-    struct GPUArchitectureTarget;
+    struct ROCROLLER_DECLSPEC GPUArchitectureTarget;
 }

--- a/lib/include/rocRoller/GPUArchitecture/GPUArchitecture_fwd.hpp
+++ b/lib/include/rocRoller/GPUArchitecture/GPUArchitecture_fwd.hpp
@@ -26,7 +26,9 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
-    class GPUArchitecture;
+    class ROCROLLER_DECLSPEC GPUArchitecture;
 }

--- a/lib/include/rocRoller/GPUArchitecture/GPUCapability.hpp
+++ b/lib/include/rocRoller/GPUArchitecture/GPUCapability.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <array>
 #include <cstdio>
 #include <fstream>
@@ -42,7 +44,7 @@
 
 namespace rocRoller
 {
-    class GPUCapability
+    class ROCROLLER_DECLSPEC GPUCapability
     {
     public:
         enum Value : uint8_t
@@ -200,7 +202,7 @@ namespace rocRoller
 
         static std::string toString(Value);
 
-        struct Hash
+        struct ROCROLLER_DECLSPEC Hash
         {
             std::size_t operator()(const GPUCapability& input) const
             {
@@ -216,7 +218,7 @@ namespace rocRoller
         static const std::unordered_map<std::string, Value> m_stringMap;
     };
 
-    std::ostream& operator<<(std::ostream&, GPUCapability::Value);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, GPUCapability::Value);
 }
 
 #include <rocRoller/GPUArchitecture/GPUCapability_impl.hpp>

--- a/lib/include/rocRoller/GPUArchitecture/GPUInstructionInfo.hpp
+++ b/lib/include/rocRoller/GPUArchitecture/GPUInstructionInfo.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <array>
 #include <cstdio>
 #include <fstream>
@@ -43,7 +45,7 @@
 
 namespace rocRoller
 {
-    class GPUWaitQueueType
+    class ROCROLLER_DECLSPEC GPUWaitQueueType
     {
     public:
         enum Value : uint8_t
@@ -84,7 +86,7 @@ namespace rocRoller
 
         static std::string toString(Value);
 
-        struct Hash
+        struct ROCROLLER_DECLSPEC Hash
         {
             std::size_t operator()(const GPUWaitQueueType& input) const
             {
@@ -103,9 +105,9 @@ namespace rocRoller
         static const std::unordered_map<std::string, Value> m_stringMap;
     };
 
-    std::ostream& operator<<(std::ostream&, GPUWaitQueueType::Value const& v);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, GPUWaitQueueType::Value const& v);
 
-    class GPUWaitQueue
+    class ROCROLLER_DECLSPEC GPUWaitQueue
     {
     public:
         enum Value : uint8_t
@@ -173,7 +175,7 @@ namespace rocRoller
 
         static std::string toString(Value);
 
-        struct Hash
+        struct ROCROLLER_DECLSPEC Hash
         {
             std::size_t operator()(const GPUWaitQueue& input) const
             {
@@ -186,9 +188,9 @@ namespace rocRoller
         static std::unordered_map<std::string, Value> m_stringMap;
     };
 
-    std::ostream& operator<<(std::ostream&, GPUWaitQueue::Value const& v);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, GPUWaitQueue::Value const& v);
 
-    class GPUInstructionInfo
+    class ROCROLLER_DECLSPEC GPUInstructionInfo
     {
     public:
         GPUInstructionInfo() = default;

--- a/lib/include/rocRoller/GPUArchitecture/GPUInstructionInfo_fwd.hpp
+++ b/lib/include/rocRoller/GPUArchitecture/GPUInstructionInfo_fwd.hpp
@@ -26,8 +26,10 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
-    class GPUInstructionInfo;
-    class GPUWaitQueueType;
+    class ROCROLLER_DECLSPEC GPUInstructionInfo;
+    class ROCROLLER_DECLSPEC GPUWaitQueueType;
 }

--- a/lib/include/rocRoller/Graph/GraphUtilities.hpp
+++ b/lib/include/rocRoller/Graph/GraphUtilities.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 
 #include <rocRoller/Graph/Hypergraph.hpp>
@@ -43,7 +45,7 @@ namespace rocRoller
          * source, only following edges that satisfy edgePredicate.
          */
         template <CCalmGraph AGraph, std::predicate<int> EdgePredicate>
-        void removeRedundantEdges(AGraph& graph, EdgePredicate edgePredicate);
+        ROCROLLER_DECLSPEC void removeRedundantEdges(AGraph& graph, EdgePredicate edgePredicate);
 
         /**
          * `graph` must be an instantiation of Hypergraph which is calm (i.e.
@@ -54,7 +56,8 @@ namespace rocRoller
          * source, only following edges that satisfy edgePredicate.
          */
         template <CCalmGraph AGraph, std::predicate<int> EdgePredicate>
-        Generator<int> findRedundantEdges(AGraph const& graph, EdgePredicate edgePredicate);
+        ROCROLLER_DECLSPEC Generator<int> findRedundantEdges(AGraph const& graph,
+                                                             EdgePredicate edgePredicate);
     }
 }
 

--- a/lib/include/rocRoller/Graph/Hypergraph.hpp
+++ b/lib/include/rocRoller/Graph/Hypergraph.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <boost/multi_index/identity.hpp>
 #include <boost/multi_index/key.hpp>
 #include <boost/multi_index/member.hpp>
@@ -80,11 +82,11 @@ namespace rocRoller
             Count
         };
 
-        std::string toString(GraphModification m);
+        ROCROLLER_DECLSPEC std::string toString(GraphModification m);
 
         namespace mi = boost::multi_index;
 
-        struct HypergraphIncident
+        struct ROCROLLER_DECLSPEC HypergraphIncident
         {
             int src;
             int dst;
@@ -92,7 +94,7 @@ namespace rocRoller
         };
 
         template <typename Node, typename Edge, bool Hyper = true>
-        class Hypergraph
+        class ROCROLLER_DECLSPEC Hypergraph
         {
         public:
             using Element = std::variant<Node, Edge>;
@@ -106,7 +108,7 @@ namespace rocRoller
             /**
              *
              */
-            struct Location
+            struct ROCROLLER_DECLSPEC Location
             {
                 int              index;
                 std::vector<int> incoming;
@@ -421,13 +423,13 @@ namespace rocRoller
             // TODO: May need to replace with multi_index for in-place rewriting.
             std::map<int, Element> m_elements;
 
-            struct BySrc
+            struct ROCROLLER_DECLSPEC BySrc
             {
             };
-            struct ByDst
+            struct ROCROLLER_DECLSPEC ByDst
             {
             };
-            struct BySrcDst
+            struct ROCROLLER_DECLSPEC BySrcDst
             {
             };
 
@@ -449,10 +451,11 @@ namespace rocRoller
         };
 
         template <typename Node, typename Edge, bool Hyper>
-        std::ostream& operator<<(std::ostream& stream, Hypergraph<Node, Edge, Hyper> const& graph);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&                        stream,
+                                                    Hypergraph<Node, Edge, Hyper> const& graph);
 
         template <typename Cls>
-        std::string variantToString(Cls const& el)
+        ROCROLLER_DECLSPEC std::string variantToString(Cls const& el)
         {
             return std::visit([](auto const& v) { return toString(v); }, el);
         }
@@ -471,11 +474,12 @@ namespace rocRoller
          * @param destNodePredicate Only yield nodes that satisfy this predicate.
          */
         template <Graph::Direction Dir, typename Node, typename Edge, bool Hyper>
-        Generator<int> reachableNodes(Graph::Hypergraph<Node, Edge, Hyper> const& graph,
-                                      int                                         start,
-                                      auto                                        nodePredicate,
-                                      auto                                        edgePredicate,
-                                      auto destNodePredicate);
+        ROCROLLER_DECLSPEC Generator<int>
+                           reachableNodes(Graph::Hypergraph<Node, Edge, Hyper> const& graph,
+                                          int                                         start,
+                                          auto                                        nodePredicate,
+                                          auto                                        edgePredicate,
+                                          auto                                        destNodePredicate);
 
         template <typename T>
         concept CCalmGraph = !T::IsHyper;

--- a/lib/include/rocRoller/InstructionValues/LDSAllocator.hpp
+++ b/lib/include/rocRoller/InstructionValues/LDSAllocator.hpp
@@ -26,13 +26,15 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/InstructionValues/Register_fwd.hpp>
 
 #include <list>
 
 namespace rocRoller
 {
-    class LDSAllocation;
+    class ROCROLLER_DECLSPEC LDSAllocation;
 
     /**
      * @brief An LDSAllocator is used to create LDSAllocations. These are
@@ -44,7 +46,7 @@ namespace rocRoller
      * blocks that have been deallocated.
      *
      */
-    class LDSAllocator : public std::enable_shared_from_this<LDSAllocator>
+    class ROCROLLER_DECLSPEC LDSAllocator : public std::enable_shared_from_this<LDSAllocator>
     {
     public:
         /**
@@ -106,7 +108,7 @@ namespace rocRoller
      * allocated.
      *
      */
-    class LDSAllocation : public std::enable_shared_from_this<LDSAllocation>
+    class ROCROLLER_DECLSPEC LDSAllocation : public std::enable_shared_from_this<LDSAllocation>
     {
         friend class LDSAllocator;
 

--- a/lib/include/rocRoller/InstructionValues/LDSAllocator_fwd.hpp
+++ b/lib/include/rocRoller/InstructionValues/LDSAllocator_fwd.hpp
@@ -26,8 +26,10 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
-    class LDSAllocation;
-    class LDSAllocator;
+    class ROCROLLER_DECLSPEC LDSAllocation;
+    class ROCROLLER_DECLSPEC LDSAllocator;
 }

--- a/lib/include/rocRoller/InstructionValues/LabelAllocator.hpp
+++ b/lib/include/rocRoller/InstructionValues/LabelAllocator.hpp
@@ -26,11 +26,13 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/InstructionValues/Register_fwd.hpp>
 
 namespace rocRoller
 {
-    class LabelAllocator
+    class ROCROLLER_DECLSPEC LabelAllocator
     {
     public:
         LabelAllocator(std::string prefix);

--- a/lib/include/rocRoller/InstructionValues/LabelAllocator_fwd.hpp
+++ b/lib/include/rocRoller/InstructionValues/LabelAllocator_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 namespace rocRoller
 {
-    class LabelAllocator;
+    class ROCROLLER_DECLSPEC LabelAllocator;
     using LabelAllocatorPtr = std::shared_ptr<LabelAllocator>;
 }

--- a/lib/include/rocRoller/InstructionValues/Register.hpp
+++ b/lib/include/rocRoller/InstructionValues/Register.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <bit>
 #include <cassert>
 #include <concepts>
@@ -64,7 +66,7 @@ namespace rocRoller
 
             Count = 255,
         };
-        struct AllocationOptions
+        struct ROCROLLER_DECLSPEC AllocationOptions
         {
             /// In units of registers
             int contiguousChunkWidth = VALUE_CONTIGUOUS;
@@ -78,7 +80,7 @@ namespace rocRoller
             auto operator<=>(AllocationOptions const& other) const = default;
         };
 
-        struct RegisterId
+        struct ROCROLLER_DECLSPEC RegisterId
         {
             RegisterId(Type regType, int index)
                 : regType(regType)
@@ -91,12 +93,12 @@ namespace rocRoller
             std::string toString() const;
         };
 
-        std::string toString(RegisterId const& regId);
+        ROCROLLER_DECLSPEC std::string toString(RegisterId const& regId);
 
         // For some reason, GCC will not find the operator declared in Utils.hpp.
-        std::ostream& operator<<(std::ostream& stream, RegisterId const& regId);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, RegisterId const& regId);
 
-        struct RegisterIdHash
+        struct ROCROLLER_DECLSPEC RegisterIdHash
         {
             size_t operator()(RegisterId const& regId) const noexcept
             {
@@ -141,7 +143,7 @@ namespace rocRoller
          * Maintains a `shared_ptr` reference to the `Allocation` object.
          *
          */
-        struct Value : public std::enable_shared_from_this<Value>
+        struct ROCROLLER_DECLSPEC Value : public std::enable_shared_from_this<Value>
         {
         public:
             Value();
@@ -451,7 +453,7 @@ namespace rocRoller
          *
          * TODO: Make not copyable, enforce construction through shared_ptr
          */
-        struct Allocation : public std::enable_shared_from_this<Allocation>
+        struct ROCROLLER_DECLSPEC Allocation : public std::enable_shared_from_this<Allocation>
         {
             Allocation(ContextPtr        context,
                        Type              regType,
@@ -525,8 +527,9 @@ namespace rocRoller
             void setRegisterCount();
         };
 
-        std::string   toString(AllocationOptions const& opts);
-        std::ostream& operator<<(std::ostream& stream, AllocationOptions const& opts);
+        ROCROLLER_DECLSPEC std::string toString(AllocationOptions const& opts);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&            stream,
+                                                    AllocationOptions const& opts);
     }
 }
 

--- a/lib/include/rocRoller/InstructionValues/RegisterAllocator.hpp
+++ b/lib/include/rocRoller/InstructionValues/RegisterAllocator.hpp
@@ -26,9 +26,11 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/InstructionValues/Register.hpp>
 
-class RegisterTest_RegisterToString_Test;
+class ROCROLLER_DECLSPEC RegisterTest_RegisterToString_Test;
 
 namespace rocRoller
 {
@@ -42,10 +44,10 @@ namespace rocRoller
             Count,
         };
 
-        std::string   toString(AllocatorScheme a);
-        std::ostream& operator<<(std::ostream&, AllocatorScheme const&);
+        ROCROLLER_DECLSPEC std::string toString(AllocatorScheme a);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, AllocatorScheme const&);
 
-        class Allocator : public std::enable_shared_from_this<Allocator>
+        class ROCROLLER_DECLSPEC Allocator : public std::enable_shared_from_this<Allocator>
         {
         public:
             Allocator(Type            regType,

--- a/lib/include/rocRoller/InstructionValues/RegisterAllocator_fwd.hpp
+++ b/lib/include/rocRoller/InstructionValues/RegisterAllocator_fwd.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <cassert>
 #include <concepts>
 
@@ -33,7 +35,7 @@ namespace rocRoller
 {
     namespace Register
     {
-        class Allocator;
+        class ROCROLLER_DECLSPEC Allocator;
     }
 
 }

--- a/lib/include/rocRoller/InstructionValues/Register_fwd.hpp
+++ b/lib/include/rocRoller/InstructionValues/Register_fwd.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <cassert>
 #include <concepts>
 #include <memory>
@@ -67,20 +69,20 @@ namespace rocRoller
             Count
         };
 
-        struct RegisterId;
-        struct RegisterIdHash;
+        struct ROCROLLER_DECLSPEC RegisterId;
+        struct ROCROLLER_DECLSPEC RegisterIdHash;
 
-        class Allocation;
-        struct Value;
+        class ROCROLLER_DECLSPEC  Allocation;
+        struct ROCROLLER_DECLSPEC Value;
 
         using AllocationPtr = std::shared_ptr<Allocation>;
         using ValuePtr      = std::shared_ptr<Value>;
 
-        std::string   toString(Type t);
-        std::ostream& operator<<(std::ostream& stream, Type t);
+        ROCROLLER_DECLSPEC std::string toString(Type t);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, Type t);
 
-        std::string   toString(AllocationState state);
-        std::ostream& operator<<(std::ostream& stream, AllocationState state);
+        ROCROLLER_DECLSPEC std::string toString(AllocationState state);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, AllocationState state);
     }
 
 }

--- a/lib/include/rocRoller/KernelArguments.hpp
+++ b/lib/include/rocRoller/KernelArguments.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -36,7 +38,7 @@
 
 namespace rocRoller
 {
-    class KernelArguments
+    class ROCROLLER_DECLSPEC KernelArguments
     {
     public:
         explicit KernelArguments(bool log = true, size_t bytes = 0);
@@ -71,7 +73,7 @@ namespace rocRoller
 
         using ArgPair = std::pair<void const*, size_t>;
 
-        class const_iterator
+        class ROCROLLER_DECLSPEC const_iterator
         {
         public:
             using iterator_category = std::input_iterator_tag;
@@ -136,8 +138,9 @@ namespace rocRoller
         bool m_log;
     };
 
-    std::ostream& operator<<(std::ostream& stream, const KernelArguments& t);
-    std::ostream& operator<<(std::ostream& stream, const KernelArguments::const_iterator& iter);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, const KernelArguments& t);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&                          stream,
+                                                const KernelArguments::const_iterator& iter);
 
 } // namespace rocRoller
 

--- a/lib/include/rocRoller/KernelArguments_fwd.hpp
+++ b/lib/include/rocRoller/KernelArguments_fwd.hpp
@@ -26,9 +26,11 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
 
-    class KernelArguments;
+    class ROCROLLER_DECLSPEC KernelArguments;
 
 }

--- a/lib/include/rocRoller/KernelGraph/Constraints.hpp
+++ b/lib/include/rocRoller/KernelGraph/Constraints.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/KernelGraph/KernelGraph_fwd.hpp>
 
 namespace rocRoller
@@ -36,7 +38,7 @@ namespace rocRoller
          * @brief Return value for any function that applies constraints to the KernelGraph.
          *
          */
-        struct ConstraintStatus
+        struct ROCROLLER_DECLSPEC ConstraintStatus
         {
             bool        satisfied   = true;
             std::string explanation = "";
@@ -57,9 +59,9 @@ namespace rocRoller
             }
         };
 
-        ConstraintStatus NoDanglingMappings(const KernelGraph& k);
-        ConstraintStatus SingleControlRoot(const KernelGraph& k);
-        ConstraintStatus NoRedundantSetCoordinates(const KernelGraph& k);
+        ROCROLLER_DECLSPEC ConstraintStatus NoDanglingMappings(const KernelGraph& k);
+        ROCROLLER_DECLSPEC ConstraintStatus SingleControlRoot(const KernelGraph& k);
+        ROCROLLER_DECLSPEC ConstraintStatus NoRedundantSetCoordinates(const KernelGraph& k);
 
         using GraphConstraint = ConstraintStatus (*)(const KernelGraph& k);
     }

--- a/lib/include/rocRoller/KernelGraph/ControlGraph/ControlEdge.hpp
+++ b/lib/include/rocRoller/KernelGraph/ControlGraph/ControlEdge.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 
 #include <rocRoller/KernelGraph/ControlGraph/ControlEdge_fwd.hpp>

--- a/lib/include/rocRoller/KernelGraph/ControlGraph/ControlEdge_fwd.hpp
+++ b/lib/include/rocRoller/KernelGraph/ControlGraph/ControlEdge_fwd.hpp
@@ -26,18 +26,20 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <variant>
 
 namespace rocRoller
 {
     namespace KernelGraph::ControlGraph
     {
-        struct Sequence;
-        struct Body; // Of kernel, for loop, if, etc.
-        struct Else; // Alternative body for false conditional
+        struct ROCROLLER_DECLSPEC Sequence;
+        struct ROCROLLER_DECLSPEC Body; // Of kernel, for loop, if, etc.
+        struct ROCROLLER_DECLSPEC Else; // Alternative body for false conditional
 
-        struct Initialize;
-        struct ForLoopIncrement;
+        struct ROCROLLER_DECLSPEC Initialize;
+        struct ROCROLLER_DECLSPEC ForLoopIncrement;
 
         using ControlEdge = std::variant<Sequence, Initialize, ForLoopIncrement, Body, Else>;
 

--- a/lib/include/rocRoller/KernelGraph/ControlGraph/ControlFlowRWTracer.hpp
+++ b/lib/include/rocRoller/KernelGraph/ControlGraph/ControlFlowRWTracer.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <variant>
 #include <vector>
 
@@ -44,7 +46,7 @@ namespace rocRoller::KernelGraph
      * recorded trace for all operations in the control graph that
      * access or modify a coordinate.
      */
-    class ControlFlowRWTracer
+    class ROCROLLER_DECLSPEC ControlFlowRWTracer
     {
     public:
         enum ReadWrite
@@ -56,7 +58,7 @@ namespace rocRoller::KernelGraph
             Count
         };
 
-        struct ReadWriteRecord
+        struct ROCROLLER_DECLSPEC ReadWriteRecord
         {
             int       control, coordinate;
             ReadWrite rw;
@@ -146,10 +148,11 @@ namespace rocRoller::KernelGraph
         void trace(int start);
     };
 
-    std::string toString(ControlFlowRWTracer::ReadWrite rw);
+    ROCROLLER_DECLSPEC std::string toString(ControlFlowRWTracer::ReadWrite rw);
 
-    std::string toString(ControlFlowRWTracer::ReadWriteRecord const& record);
+    ROCROLLER_DECLSPEC std::string toString(ControlFlowRWTracer::ReadWriteRecord const& record);
 
-    std::ostream& operator<<(std::ostream& stream, ControlFlowRWTracer::ReadWrite rw);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&                  stream,
+                                                ControlFlowRWTracer::ReadWrite rw);
 
 }

--- a/lib/include/rocRoller/KernelGraph/ControlGraph/ControlGraph.hpp
+++ b/lib/include/rocRoller/KernelGraph/ControlGraph/ControlGraph.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <functional>
 #include <variant>
 
@@ -78,24 +80,24 @@ namespace rocRoller
         /**
          * Return a full representation of 'n'
          */
-        std::string   toString(NodeOrdering n);
-        std::ostream& operator<<(std::ostream& stream, NodeOrdering n);
+        ROCROLLER_DECLSPEC std::string toString(NodeOrdering n);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, NodeOrdering n);
 
         /**
          * Return a full representation of 'c'
          */
-        std::string   toString(CacheStatus c);
-        std::ostream& operator<<(std::ostream& stream, CacheStatus c);
+        ROCROLLER_DECLSPEC std::string toString(CacheStatus c);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, CacheStatus c);
 
         /**
          * Return a 3-character representation of 'n'.
          */
-        std::string abbrev(NodeOrdering n);
+        ROCROLLER_DECLSPEC std::string abbrev(NodeOrdering n);
 
         /**
          * If ordering `order` applies to (a, b), return the ordering that applies to (b, a).
          */
-        NodeOrdering opposite(NodeOrdering order);
+        ROCROLLER_DECLSPEC NodeOrdering opposite(NodeOrdering order);
 
         /**
          * Control flow graph.
@@ -103,7 +105,8 @@ namespace rocRoller
          * Nodes in the graph represent operations.  Edges describe
          * dependencies.
          */
-        class ControlGraph : public Graph::Hypergraph<Operation, ControlEdge, false>
+        class ROCROLLER_DECLSPEC ControlGraph
+            : public Graph::Hypergraph<Operation, ControlEdge, false>
         {
         public:
             using Base = Graph::Hypergraph<Operation, ControlEdge, false>;

--- a/lib/include/rocRoller/KernelGraph/ControlGraph/ControlGraph_fwd.hpp
+++ b/lib/include/rocRoller/KernelGraph/ControlGraph/ControlGraph_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace KernelGraph::ControlGraph
     {
-        class ControlGraph;
+        class ROCROLLER_DECLSPEC ControlGraph;
     }
 }

--- a/lib/include/rocRoller/KernelGraph/ControlGraph/LastRWTracer.hpp
+++ b/lib/include/rocRoller/KernelGraph/ControlGraph/LastRWTracer.hpp
@@ -26,11 +26,13 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/KernelGraph/ControlGraph/ControlFlowRWTracer.hpp>
 
 namespace rocRoller::KernelGraph
 {
-    class LastRWTracer : public ControlFlowRWTracer
+    class ROCROLLER_DECLSPEC LastRWTracer : public ControlFlowRWTracer
     {
     public:
         LastRWTracer(KernelGraph const& graph, int start = -1, bool trackConnections = false)

--- a/lib/include/rocRoller/KernelGraph/ControlGraph/Operation.hpp
+++ b/lib/include/rocRoller/KernelGraph/ControlGraph/Operation.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <cstdint>
 #include <initializer_list>
 #include <string>
@@ -62,7 +64,7 @@ namespace rocRoller
         /**
          * SetCoordinate - Sets the value of a Coordinate
          */
-        struct SetCoordinate
+        struct ROCROLLER_DECLSPEC SetCoordinate
         {
             SetCoordinate();
             explicit SetCoordinate(Expression::ExpressionPtr value);
@@ -90,7 +92,7 @@ namespace rocRoller
          * if(condition) goto while_top
          * <Sequence>
          */
-        struct DoWhileOp
+        struct ROCROLLER_DECLSPEC DoWhileOp
         {
             Expression::ExpressionPtr condition;
 
@@ -124,7 +126,7 @@ namespace rocRoller
          * for_bottom:
          * <Sequence>
          */
-        struct ForLoopOp
+        struct ROCROLLER_DECLSPEC ForLoopOp
         {
             Expression::ExpressionPtr condition;
 
@@ -153,7 +155,7 @@ namespace rocRoller
          * <Sequence>
          *
         */
-        struct ConditionalOp
+        struct ROCROLLER_DECLSPEC ConditionalOp
         {
             Expression::ExpressionPtr condition;
 
@@ -180,7 +182,7 @@ namespace rocRoller
          * Where <terminates kernel> is a instruction sequence that causes a trap or exception in kernel code.
          *
         */
-        struct AssertOp
+        struct ROCROLLER_DECLSPEC AssertOp
         {
             std::string assertName;
 
@@ -193,7 +195,7 @@ namespace rocRoller
         /**
          * UnrollOp - a kernel unroll.
          */
-        struct UnrollOp
+        struct ROCROLLER_DECLSPEC UnrollOp
         {
             Expression::ExpressionPtr size;
 
@@ -207,7 +209,7 @@ namespace rocRoller
          * If the register already exists, it must be of type 'regType'.  If not, `regType`
          * specifies which type of register will be allocated.
          */
-        struct Assign
+        struct ROCROLLER_DECLSPEC Assign
         {
             Register::Type            regType = Register::Type::Count;
             Expression::ExpressionPtr expression;
@@ -240,7 +242,7 @@ namespace rocRoller
          * @param increment Increment dimension
          * @param base
          */
-        struct ComputeIndex
+        struct ROCROLLER_DECLSPEC ComputeIndex
         {
             // TODO: might be nicer to have UInt32 for strides; need
             // to allow user to specify stride types instead of
@@ -267,7 +269,7 @@ namespace rocRoller
         /**
          * LoadLinear - Load linear dimension.
          */
-        struct LoadLinear
+        struct ROCROLLER_DECLSPEC LoadLinear
         {
             LoadLinear();
             explicit LoadLinear(rocRoller::VariableType const varType);
@@ -288,7 +290,7 @@ namespace rocRoller
          * instructions) is specified by the `LayoutType` member of
          * the the WaveTile node.
          */
-        struct LoadTiled
+        struct ROCROLLER_DECLSPEC LoadTiled
         {
             LoadTiled();
             explicit LoadTiled(VariableType const varType, bool const isTransposedTile = false);
@@ -302,7 +304,7 @@ namespace rocRoller
         /**
          * LoadVGPR - replaces LoadLinear.
          */
-        struct LoadVGPR
+        struct ROCROLLER_DECLSPEC LoadVGPR
         {
             LoadVGPR();
             explicit LoadVGPR(VariableType const varType, bool const scalar = false);
@@ -316,7 +318,7 @@ namespace rocRoller
         /**
          * LoadSGPR - load scalar value from memory.
          */
-        struct LoadSGPR
+        struct ROCROLLER_DECLSPEC LoadSGPR
         {
             LoadSGPR();
             LoadSGPR(VariableType const varType, BufferInstructionOptions const bio);
@@ -330,7 +332,7 @@ namespace rocRoller
         /**
          * LoadLDSTile - loads a tile from LDS
          */
-        struct LoadLDSTile
+        struct ROCROLLER_DECLSPEC LoadLDSTile
         {
             LoadLDSTile();
             explicit LoadLDSTile(VariableType const varType, bool const isTransposedTile = false);
@@ -342,7 +344,7 @@ namespace rocRoller
             std::string toString() const;
         };
 
-        struct LoadTileDirect2LDS
+        struct ROCROLLER_DECLSPEC LoadTileDirect2LDS
         {
             LoadTileDirect2LDS();
             explicit LoadTileDirect2LDS(VariableType const varType);
@@ -355,7 +357,7 @@ namespace rocRoller
         /**
          * Multiply - Multiply two MacroTiles
          */
-        struct Multiply
+        struct ROCROLLER_DECLSPEC Multiply
         {
             Multiply();
             Multiply(Operations::ScaleMode scaleA, Operations::ScaleMode scaleB);
@@ -387,7 +389,7 @@ namespace rocRoller
          * Storage location and affinity is specified by the MacroTile
          * node.
          */
-        struct StoreTiled
+        struct ROCROLLER_DECLSPEC StoreTiled
         {
             StoreTiled();
             explicit StoreTiled(VariableType const dtype);
@@ -406,7 +408,7 @@ namespace rocRoller
         /**
          * StoreSGPR - stores a scalar value to memory.
          */
-        struct StoreSGPR
+        struct ROCROLLER_DECLSPEC StoreSGPR
         {
             StoreSGPR();
             StoreSGPR(VariableType const varType, BufferInstructionOptions const bio);
@@ -420,7 +422,7 @@ namespace rocRoller
         /**
          * StoreLDSTile - store a tile into LDS
          */
-        struct StoreLDSTile
+        struct ROCROLLER_DECLSPEC StoreLDSTile
         {
             StoreLDSTile();
             explicit StoreLDSTile(VariableType const varType);
@@ -433,7 +435,7 @@ namespace rocRoller
         /**
          * TensorContraction - Tensor contraction operation.
          */
-        struct TensorContraction
+        struct ROCROLLER_DECLSPEC TensorContraction
         {
             TensorContraction();
             TensorContraction(std::vector<int> const& aContractedDimensions,
@@ -465,7 +467,7 @@ namespace rocRoller
         /**
          * Exchange - permute the lanes data within a wave.
          */
-        struct Exchange
+        struct ROCROLLER_DECLSPEC Exchange
         {
             Exchange();
             explicit Exchange(VariableType const varType);
@@ -478,7 +480,7 @@ namespace rocRoller
         /**
          * SeedPRNG - Set the initial seed value of a random number generator
          */
-        struct SeedPRNG
+        struct ROCROLLER_DECLSPEC SeedPRNG
         {
             SeedPRNG();
             explicit SeedPRNG(bool addTID);

--- a/lib/include/rocRoller/KernelGraph/ControlGraph/Operation_fwd.hpp
+++ b/lib/include/rocRoller/KernelGraph/ControlGraph/Operation_fwd.hpp
@@ -26,42 +26,44 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <variant>
 
 namespace rocRoller
 {
     namespace KernelGraph::ControlGraph
     {
-        struct Assign;
-        struct Barrier;
-        struct ComputeIndex;
-        struct ConditionalOp;
-        struct AssertOp;
-        struct Deallocate;
-        struct DoWhileOp;
-        struct Exchange;
-        struct ForLoopOp;
-        struct Kernel;
-        struct LoadLDSTile;
-        struct LoadLinear;
-        struct LoadVGPR;
-        struct LoadSGPR;
-        struct LoadTiled;
-        struct Multiply;
-        struct NOP;
-        struct Block;
-        struct Scope;
-        struct SetCoordinate;
-        struct StoreLDSTile;
-        struct LoadTileDirect2LDS;
-        struct StoreLinear;
-        struct StoreTiled;
-        struct StoreVGPR;
-        struct StoreSGPR;
-        struct TensorContraction;
-        struct UnrollOp;
-        struct WaitZero;
-        struct SeedPRNG;
+        struct ROCROLLER_DECLSPEC Assign;
+        struct ROCROLLER_DECLSPEC Barrier;
+        struct ROCROLLER_DECLSPEC ComputeIndex;
+        struct ROCROLLER_DECLSPEC ConditionalOp;
+        struct ROCROLLER_DECLSPEC AssertOp;
+        struct ROCROLLER_DECLSPEC Deallocate;
+        struct ROCROLLER_DECLSPEC DoWhileOp;
+        struct ROCROLLER_DECLSPEC Exchange;
+        struct ROCROLLER_DECLSPEC ForLoopOp;
+        struct ROCROLLER_DECLSPEC Kernel;
+        struct ROCROLLER_DECLSPEC LoadLDSTile;
+        struct ROCROLLER_DECLSPEC LoadLinear;
+        struct ROCROLLER_DECLSPEC LoadVGPR;
+        struct ROCROLLER_DECLSPEC LoadSGPR;
+        struct ROCROLLER_DECLSPEC LoadTiled;
+        struct ROCROLLER_DECLSPEC Multiply;
+        struct ROCROLLER_DECLSPEC NOP;
+        struct ROCROLLER_DECLSPEC Block;
+        struct ROCROLLER_DECLSPEC Scope;
+        struct ROCROLLER_DECLSPEC SetCoordinate;
+        struct ROCROLLER_DECLSPEC StoreLDSTile;
+        struct ROCROLLER_DECLSPEC LoadTileDirect2LDS;
+        struct ROCROLLER_DECLSPEC StoreLinear;
+        struct ROCROLLER_DECLSPEC StoreTiled;
+        struct ROCROLLER_DECLSPEC StoreVGPR;
+        struct ROCROLLER_DECLSPEC StoreSGPR;
+        struct ROCROLLER_DECLSPEC TensorContraction;
+        struct ROCROLLER_DECLSPEC UnrollOp;
+        struct ROCROLLER_DECLSPEC WaitZero;
+        struct ROCROLLER_DECLSPEC SeedPRNG;
 
         using Operation = std::variant<Assign,
                                        Barrier,

--- a/lib/include/rocRoller/KernelGraph/ControlToCoordinateMapper.hpp
+++ b/lib/include/rocRoller/KernelGraph/ControlToCoordinateMapper.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <map>
 #include <sstream>
 #include <string>
@@ -50,14 +52,14 @@ namespace rocRoller::KernelGraph
      */
     namespace Connections
     {
-        struct JustNaryArgument
+        struct ROCROLLER_DECLSPEC JustNaryArgument
         {
             NaryArgument argument;
 
             auto operator<=>(JustNaryArgument const&) const = default;
         };
 
-        struct TypeAndSubDimension
+        struct ROCROLLER_DECLSPEC TypeAndSubDimension
         {
             std::string id;
             int         subdimension;
@@ -70,7 +72,7 @@ namespace rocRoller::KernelGraph
             return a.id < b.id;
         }
 
-        struct TypeAndNaryArgument
+        struct ROCROLLER_DECLSPEC TypeAndNaryArgument
         {
             std::string  id;
             NaryArgument argument;
@@ -101,10 +103,10 @@ namespace rocRoller::KernelGraph
             Count
         };
 
-        std::string   toString(ComputeIndexArgument cia);
-        std::ostream& operator<<(std::ostream&, ComputeIndexArgument const&);
+        ROCROLLER_DECLSPEC std::string toString(ComputeIndexArgument cia);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, ComputeIndexArgument const&);
 
-        struct ComputeIndex
+        struct ROCROLLER_DECLSPEC ComputeIndex
         {
             ComputeIndexArgument argument;
             int                  index = 0;
@@ -123,13 +125,13 @@ namespace rocRoller::KernelGraph
                                             TypeAndSubDimension,
                                             TypeAndNaryArgument>;
 
-        std::string   name(ConnectionSpec const& cs);
-        std::string   toString(ConnectionSpec const& cs);
-        std::ostream& operator<<(std::ostream& stream, ConnectionSpec const& cs);
+        ROCROLLER_DECLSPEC std::string name(ConnectionSpec const& cs);
+        ROCROLLER_DECLSPEC std::string toString(ConnectionSpec const& cs);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, ConnectionSpec const& cs);
 
     }
 
-    struct DeferredConnection
+    struct ROCROLLER_DECLSPEC DeferredConnection
     {
         Connections::ConnectionSpec connectionSpec;
         int                         coordinate;
@@ -156,14 +158,14 @@ namespace rocRoller::KernelGraph
      * coordinates.  To accomplish this, connection specifiers (see
      * ConnectionSpec) are used.
      */
-    class ControlToCoordinateMapper
+    class ROCROLLER_DECLSPEC ControlToCoordinateMapper
     {
         // key_type is:
         //  control graph index, connection specification
         using key_type = std::tuple<int, Connections::ConnectionSpec>;
 
     public:
-        struct Connection
+        struct ROCROLLER_DECLSPEC Connection
         {
             int                         control;
             int                         coordinate;

--- a/lib/include/rocRoller/KernelGraph/CoordinateGraph/CoordinateEdge.hpp
+++ b/lib/include/rocRoller/KernelGraph/CoordinateGraph/CoordinateEdge.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 
 #include <rocRoller/KernelGraph/CoordinateGraph/CoordinateEdge_fwd.hpp>
@@ -96,7 +98,7 @@ namespace rocRoller
          * Index - denotes that the source will index the register
          * allocation from the dest.
          */
-        struct Index
+        struct ROCROLLER_DECLSPEC Index
         {
             int index = -1;
 

--- a/lib/include/rocRoller/KernelGraph/CoordinateGraph/CoordinateEdgeVisitor.hpp
+++ b/lib/include/rocRoller/KernelGraph/CoordinateGraph/CoordinateEdgeVisitor.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <vector>
 
 #include <rocRoller/Expression.hpp>
@@ -41,7 +43,7 @@ namespace rocRoller
         concept CTUndefinedEdge = std::is_same<ConstructMacroTile, T>::value || std::
             is_same<DestructMacroTile, T>::value || std::is_same<Forget, T>::value;
 
-        struct BaseEdgeVisitor
+        struct ROCROLLER_DECLSPEC BaseEdgeVisitor
         {
             // index expressions for the dimensions
             std::vector<Expression::ExpressionPtr> indexes;
@@ -62,7 +64,7 @@ namespace rocRoller
             }
         };
 
-        struct ForwardEdgeVisitor : public BaseEdgeVisitor
+        struct ROCROLLER_DECLSPEC ForwardEdgeVisitor : public BaseEdgeVisitor
         {
             std::vector<Expression::ExpressionPtr> operator()(Flatten const& e)
             {
@@ -158,7 +160,7 @@ namespace rocRoller
             }
         };
 
-        struct ReverseEdgeVisitor : public BaseEdgeVisitor
+        struct ROCROLLER_DECLSPEC ReverseEdgeVisitor : public BaseEdgeVisitor
         {
             std::vector<Expression::ExpressionPtr> operator()(Flatten const& e)
             {
@@ -255,7 +257,7 @@ namespace rocRoller
         /*
          * Diff edge visitors.
          */
-        struct BaseEdgeDiffVisitor : public BaseEdgeVisitor
+        struct ROCROLLER_DECLSPEC BaseEdgeDiffVisitor : public BaseEdgeVisitor
         {
             Expression::ExpressionPtr zero;
 
@@ -286,7 +288,7 @@ namespace rocRoller
             }
         };
 
-        struct ForwardEdgeDiffVisitor : public BaseEdgeDiffVisitor
+        struct ROCROLLER_DECLSPEC ForwardEdgeDiffVisitor : public BaseEdgeDiffVisitor
         {
             using BaseEdgeDiffVisitor::BaseEdgeDiffVisitor;
 
@@ -422,7 +424,7 @@ namespace rocRoller
             }
         };
 
-        struct ReverseEdgeDiffVisitor : public BaseEdgeDiffVisitor
+        struct ROCROLLER_DECLSPEC ReverseEdgeDiffVisitor : public BaseEdgeDiffVisitor
         {
             using BaseEdgeDiffVisitor::BaseEdgeDiffVisitor;
 

--- a/lib/include/rocRoller/KernelGraph/CoordinateGraph/CoordinateEdge_fwd.hpp
+++ b/lib/include/rocRoller/KernelGraph/CoordinateGraph/CoordinateEdge_fwd.hpp
@@ -26,23 +26,25 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <variant>
 
 namespace rocRoller
 {
     namespace KernelGraph::CoordinateGraph
     {
-        struct ConstructMacroTile;
-        struct DestructMacroTile;
-        struct Flatten;
-        struct Forget;
-        struct Inherit;
-        struct Join;
-        struct MakeOutput;
-        struct PassThrough;
-        struct Split;
-        struct Sunder;
-        struct Tile;
+        struct ROCROLLER_DECLSPEC ConstructMacroTile;
+        struct ROCROLLER_DECLSPEC DestructMacroTile;
+        struct ROCROLLER_DECLSPEC Flatten;
+        struct ROCROLLER_DECLSPEC Forget;
+        struct ROCROLLER_DECLSPEC Inherit;
+        struct ROCROLLER_DECLSPEC Join;
+        struct ROCROLLER_DECLSPEC MakeOutput;
+        struct ROCROLLER_DECLSPEC PassThrough;
+        struct ROCROLLER_DECLSPEC Split;
+        struct ROCROLLER_DECLSPEC Sunder;
+        struct ROCROLLER_DECLSPEC Tile;
 
         using CoordinateTransformEdge = std::variant<ConstructMacroTile,
                                                      DestructMacroTile,
@@ -63,15 +65,15 @@ namespace rocRoller
         concept CConcreteCoordinateTransformEdge
             = (CCoordinateTransformEdge<T> && !std::same_as<CoordinateTransformEdge, T>);
 
-        struct DataFlow;
+        struct ROCROLLER_DECLSPEC DataFlow;
 
-        struct Alias;
-        struct Buffer;
-        struct Duplicate;
-        struct Index;
-        struct Offset;
-        struct Stride;
-        struct View;
+        struct ROCROLLER_DECLSPEC Alias;
+        struct ROCROLLER_DECLSPEC Buffer;
+        struct ROCROLLER_DECLSPEC Duplicate;
+        struct ROCROLLER_DECLSPEC Index;
+        struct ROCROLLER_DECLSPEC Offset;
+        struct ROCROLLER_DECLSPEC Stride;
+        struct ROCROLLER_DECLSPEC View;
 
         using DataFlowEdge
             = std::variant<DataFlow, Alias, Buffer, Duplicate, Index, Offset, Stride, View>;

--- a/lib/include/rocRoller/KernelGraph/CoordinateGraph/CoordinateGraph.hpp
+++ b/lib/include/rocRoller/KernelGraph/CoordinateGraph/CoordinateGraph.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -114,7 +116,7 @@ namespace rocRoller
          * Hyper-edges describe how to transform coordinates and/or
          * apply operations.
          */
-        class CoordinateGraph : public Graph::Hypergraph<Dimension, Edge>
+        class ROCROLLER_DECLSPEC CoordinateGraph : public Graph::Hypergraph<Dimension, Edge>
         {
         public:
             using Base = Graph::Hypergraph<Dimension, Edge>;

--- a/lib/include/rocRoller/KernelGraph/CoordinateGraph/Dimension.hpp
+++ b/lib/include/rocRoller/KernelGraph/CoordinateGraph/Dimension.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -48,7 +50,7 @@ namespace rocRoller
          * - Storage (Registers, e.g. MacroTile)
          */
 
-        struct BaseDimension
+        struct ROCROLLER_DECLSPEC BaseDimension
         {
             Expression::ExpressionPtr size, stride, offset;
 
@@ -84,7 +86,7 @@ namespace rocRoller
          *
          * Can exist in the final graph.
          */
-        struct Adhoc : public BaseDimension
+        struct ROCROLLER_DECLSPEC Adhoc : public BaseDimension
         {
             Adhoc();
 
@@ -115,7 +117,7 @@ namespace rocRoller
          *
          * Encodes size and stride info.
          */
-        struct SubDimension : public BaseDimension
+        struct ROCROLLER_DECLSPEC SubDimension : public BaseDimension
         {
             int dim;
 
@@ -135,7 +137,7 @@ namespace rocRoller
          * Usually split into SubDimensions.  The subdimensions carry
          * sizes and strides.
          */
-        struct User : public BaseDimension
+        struct ROCROLLER_DECLSPEC User : public BaseDimension
         {
             std::string argumentName;
 
@@ -164,7 +166,7 @@ namespace rocRoller
         /**
          * Linear dimension.  Usually flattened subdimenions.
          */
-        struct Linear : public BaseDimension
+        struct ROCROLLER_DECLSPEC Linear : public BaseDimension
         {
             static constexpr bool HasValue = false;
             using BaseDimension::BaseDimension;
@@ -175,7 +177,7 @@ namespace rocRoller
         /**
          * Wavefront - represents wavefronts within a workgroup.
          */
-        struct Wavefront : public SubDimension
+        struct ROCROLLER_DECLSPEC Wavefront : public SubDimension
         {
             static constexpr bool HasValue = false;
             using SubDimension::SubDimension;
@@ -186,7 +188,7 @@ namespace rocRoller
         /**
          * Lane - represents a lane within a wavefront.
          */
-        struct Lane : public BaseDimension
+        struct ROCROLLER_DECLSPEC Lane : public BaseDimension
         {
             static constexpr bool HasValue = false;
             using BaseDimension::BaseDimension;
@@ -200,7 +202,7 @@ namespace rocRoller
          * Sub-dimensions 0, 1, and 2 correspond to the x, y and z
          * kernel launch dimensions.
          */
-        struct Workgroup : public SubDimension
+        struct ROCROLLER_DECLSPEC Workgroup : public SubDimension
         {
             static constexpr bool HasValue = false;
 
@@ -215,7 +217,7 @@ namespace rocRoller
          * Sub-dimensions 0, 1, and 2 correspond to the x, y and z
          * kernel launch dimensions.
          */
-        struct Workitem : public SubDimension
+        struct ROCROLLER_DECLSPEC Workitem : public SubDimension
         {
             static constexpr bool HasValue = false;
 
@@ -228,7 +230,7 @@ namespace rocRoller
         /**
          * VGPR - represents (small) thread local scalar/array.
          */
-        struct VGPR : public BaseDimension
+        struct ROCROLLER_DECLSPEC VGPR : public BaseDimension
         {
             static constexpr bool HasValue = false;
 
@@ -237,7 +239,7 @@ namespace rocRoller
             std::string name() const override;
         };
 
-        struct VGPRBlockNumber : public BaseDimension
+        struct ROCROLLER_DECLSPEC VGPRBlockNumber : public BaseDimension
         {
             static constexpr bool HasValue = false;
 
@@ -246,7 +248,7 @@ namespace rocRoller
             std::string name() const override;
         };
 
-        struct VGPRBlockIndex : public BaseDimension
+        struct ROCROLLER_DECLSPEC VGPRBlockIndex : public BaseDimension
         {
             static constexpr bool HasValue = false;
 
@@ -262,7 +264,7 @@ namespace rocRoller
          * - Represents storage
          * - Represents address coordinate information
          */
-        struct LDS : public BaseDimension
+        struct ROCROLLER_DECLSPEC LDS : public BaseDimension
         {
             static constexpr bool HasValue = false;
             using BaseDimension::BaseDimension;
@@ -283,7 +285,7 @@ namespace rocRoller
          * ForLoop dimensions elucidate how indexes depend on which
          * for-loop iteration is being executed.
          */
-        struct ForLoop : public BaseDimension
+        struct ROCROLLER_DECLSPEC ForLoop : public BaseDimension
         {
             static constexpr bool HasValue = false;
 
@@ -299,7 +301,7 @@ namespace rocRoller
          * Unroll dimensions elucidate how indexes depend on which
          * inner-iteration of an unrolled for-loop is being executed.
          */
-        struct Unroll : public BaseDimension
+        struct ROCROLLER_DECLSPEC Unroll : public BaseDimension
         {
             static constexpr bool HasValue = false;
 
@@ -313,7 +315,7 @@ namespace rocRoller
         /**
          * MacroTileIndex - sub-dimension of a tile.  See MacroTile.
          */
-        struct MacroTileIndex : public SubDimension
+        struct ROCROLLER_DECLSPEC MacroTileIndex : public SubDimension
         {
             static constexpr bool HasValue = false;
 
@@ -325,7 +327,7 @@ namespace rocRoller
         /**
          * MacroTileNumber.  See MacroTile.
          */
-        struct MacroTileNumber : public SubDimension
+        struct ROCROLLER_DECLSPEC MacroTileNumber : public SubDimension
         {
             static constexpr bool HasValue = false;
 
@@ -340,7 +342,7 @@ namespace rocRoller
          * The storage location (eg, VGPRs vs LDS) is specified by
          * `MemoryType`.
          */
-        struct MacroTile : public BaseDimension
+        struct ROCROLLER_DECLSPEC MacroTile : public BaseDimension
         {
             int        rank       = 0;
             MemoryType memoryType = MemoryType::None;
@@ -436,7 +438,7 @@ namespace rocRoller
         /**
          * ThreadTileIndex - sub-dimension of a tile (fast-moving).
          */
-        struct ThreadTileIndex : public SubDimension
+        struct ROCROLLER_DECLSPEC ThreadTileIndex : public SubDimension
         {
             static constexpr bool HasValue = false;
 
@@ -449,7 +451,7 @@ namespace rocRoller
         /**
          * ThreadTileNumber - sub-dimension of a tile (slow-moving).
          */
-        struct ThreadTileNumber : public SubDimension
+        struct ROCROLLER_DECLSPEC ThreadTileNumber : public SubDimension
         {
             static constexpr bool HasValue = false;
 
@@ -465,7 +467,7 @@ namespace rocRoller
          * The storage location (eg, VGPRs vs LDS) is specified by
          * `MemoryType`.
          */
-        struct ThreadTile : public BaseDimension
+        struct ROCROLLER_DECLSPEC ThreadTile : public BaseDimension
         {
             int rank = -1;
 
@@ -486,7 +488,7 @@ namespace rocRoller
         /**
          * WaveTileIndex - sub-dimension of a tile.  See WaveTile.
          */
-        struct WaveTileIndex : public SubDimension
+        struct ROCROLLER_DECLSPEC WaveTileIndex : public SubDimension
         {
             static constexpr bool HasValue = false;
             using SubDimension::SubDimension;
@@ -497,7 +499,7 @@ namespace rocRoller
         /**
          * WaveTileNumber.  See WaveTile.
          */
-        struct WaveTileNumber : public SubDimension
+        struct ROCROLLER_DECLSPEC WaveTileNumber : public SubDimension
         {
             static constexpr bool HasValue = false;
             using SubDimension::SubDimension;
@@ -508,7 +510,7 @@ namespace rocRoller
         /**
          * WaveTile - a tensor tile owned by a wave in GPRs.
          */
-        struct WaveTile : public BaseDimension
+        struct ROCROLLER_DECLSPEC WaveTile : public BaseDimension
         {
             int rank = 0;
 
@@ -559,7 +561,7 @@ namespace rocRoller
         /**
          * JammedWaveTileNumber - Number of wave tiles to execute per wavefront
          */
-        struct JammedWaveTileNumber : public SubDimension
+        struct ROCROLLER_DECLSPEC JammedWaveTileNumber : public SubDimension
         {
             static constexpr bool HasValue = false;
             using SubDimension::SubDimension;
@@ -570,7 +572,7 @@ namespace rocRoller
         /**
          * ElementNumber - represents the value(s) from a ThreadTile to be stored in the VGPR(s).
          */
-        struct ElementNumber : public SubDimension
+        struct ROCROLLER_DECLSPEC ElementNumber : public SubDimension
         {
             static constexpr bool HasValue = false;
 

--- a/lib/include/rocRoller/KernelGraph/CoordinateGraph/Dimension_fwd.hpp
+++ b/lib/include/rocRoller/KernelGraph/CoordinateGraph/Dimension_fwd.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <variant>
 
 namespace rocRoller
@@ -36,31 +38,31 @@ namespace rocRoller
          * Nodes (Dimensions)
          */
 
-        struct ForLoop;
-        struct Adhoc;
-        struct ElementNumber;
-        struct Lane;
-        struct Linear;
-        struct LDS;
-        struct MacroTile;
-        struct MacroTileIndex;
-        struct MacroTileNumber;
-        struct SubDimension;
-        struct ThreadTile;
-        struct ThreadTileIndex;
-        struct ThreadTileNumber;
-        struct Unroll;
-        struct User;
-        struct VGPR;
-        struct VGPRBlockNumber;
-        struct VGPRBlockIndex;
-        struct WaveTile;
-        struct WaveTileIndex;
-        struct WaveTileNumber;
-        struct JammedWaveTileNumber;
-        struct Wavefront;
-        struct Workgroup;
-        struct Workitem;
+        struct ROCROLLER_DECLSPEC ForLoop;
+        struct ROCROLLER_DECLSPEC Adhoc;
+        struct ROCROLLER_DECLSPEC ElementNumber;
+        struct ROCROLLER_DECLSPEC Lane;
+        struct ROCROLLER_DECLSPEC Linear;
+        struct ROCROLLER_DECLSPEC LDS;
+        struct ROCROLLER_DECLSPEC MacroTile;
+        struct ROCROLLER_DECLSPEC MacroTileIndex;
+        struct ROCROLLER_DECLSPEC MacroTileNumber;
+        struct ROCROLLER_DECLSPEC SubDimension;
+        struct ROCROLLER_DECLSPEC ThreadTile;
+        struct ROCROLLER_DECLSPEC ThreadTileIndex;
+        struct ROCROLLER_DECLSPEC ThreadTileNumber;
+        struct ROCROLLER_DECLSPEC Unroll;
+        struct ROCROLLER_DECLSPEC User;
+        struct ROCROLLER_DECLSPEC VGPR;
+        struct ROCROLLER_DECLSPEC VGPRBlockNumber;
+        struct ROCROLLER_DECLSPEC VGPRBlockIndex;
+        struct ROCROLLER_DECLSPEC WaveTile;
+        struct ROCROLLER_DECLSPEC WaveTileIndex;
+        struct ROCROLLER_DECLSPEC WaveTileNumber;
+        struct ROCROLLER_DECLSPEC JammedWaveTileNumber;
+        struct ROCROLLER_DECLSPEC Wavefront;
+        struct ROCROLLER_DECLSPEC Workgroup;
+        struct ROCROLLER_DECLSPEC Workitem;
 
         using Dimension = std::variant<ForLoop,
                                        Adhoc,

--- a/lib/include/rocRoller/KernelGraph/CoordinateGraph/Transformer.hpp
+++ b/lib/include/rocRoller/KernelGraph/CoordinateGraph/Transformer.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/Expression_fwd.hpp>
 #include <rocRoller/KernelGraph/CoordinateGraph/CoordinateGraph.hpp>
@@ -41,7 +43,7 @@ namespace rocRoller
          * Workgroup and Workitem (work coordinates) are implicitly
          * set if a context is passed to the constructor.
          */
-        class Transformer
+        class ROCROLLER_DECLSPEC Transformer
         {
         public:
             Transformer() = delete;

--- a/lib/include/rocRoller/KernelGraph/CoordinateGraph/Transformer_fwd.hpp
+++ b/lib/include/rocRoller/KernelGraph/CoordinateGraph/Transformer_fwd.hpp
@@ -26,13 +26,15 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 namespace rocRoller
 {
     namespace KernelGraph::CoordinateGraph
     {
-        class Transformer;
+        class ROCROLLER_DECLSPEC Transformer;
 
         using TransformerPtr = std::shared_ptr<Transformer>;
     }

--- a/lib/include/rocRoller/KernelGraph/KernelGraph.hpp
+++ b/lib/include/rocRoller/KernelGraph/KernelGraph.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/AssemblyKernel_fwd.hpp>
 #include <rocRoller/CommandSolution_fwd.hpp>
 #include <rocRoller/Context.hpp>
@@ -52,7 +54,7 @@ namespace rocRoller
          * @brief Kernel graph container: control and coordinate graphs, control-to-coordinate mapper.
          * @ingroup KernelGraph
          */
-        class KernelGraph
+        class ROCROLLER_DECLSPEC KernelGraph
         {
             std::vector<GraphConstraint> m_constraints{
                 &NoDanglingMappings, &SingleControlRoot, &NoRedundantSetCoordinates};
@@ -119,17 +121,17 @@ namespace rocRoller
          *
          * @ingroup KernelGraph
          */
-        KernelGraph translate(CommandPtr);
+        ROCROLLER_DECLSPEC KernelGraph translate(CommandPtr);
 
         /**
          * Generate assembly from a KernelGraph.
          *
          * @ingroup KernelGraph
          */
-        Generator<Instruction> generate(KernelGraph, AssemblyKernelPtr);
+        ROCROLLER_DECLSPEC Generator<Instruction> generate(KernelGraph, AssemblyKernelPtr);
 
-        std::string toYAML(KernelGraph const& g);
-        KernelGraph fromYAML(std::string const& str);
+        ROCROLLER_DECLSPEC std::string toYAML(KernelGraph const& g);
+        ROCROLLER_DECLSPEC KernelGraph fromYAML(std::string const& str);
 
     }
 }

--- a/lib/include/rocRoller/KernelGraph/KernelGraph_fwd.hpp
+++ b/lib/include/rocRoller/KernelGraph/KernelGraph_fwd.hpp
@@ -26,15 +26,17 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 namespace rocRoller
 {
     namespace KernelGraph
     {
-        class KernelGraph;
-        struct KernelUnrollVisitor;
-        struct LoopDistributeVisitor;
+        class ROCROLLER_DECLSPEC  KernelGraph;
+        struct ROCROLLER_DECLSPEC KernelUnrollVisitor;
+        struct ROCROLLER_DECLSPEC LoopDistributeVisitor;
 
         using KernelGraphPtr = std::shared_ptr<KernelGraph>;
     }

--- a/lib/include/rocRoller/KernelGraph/Policy.hpp
+++ b/lib/include/rocRoller/KernelGraph/Policy.hpp
@@ -26,18 +26,23 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
-    class CacheOnlyPolicy // Use cache to look up order. Caller should ensure the cache is valid.
+    class ROCROLLER_DECLSPEC
+        CacheOnlyPolicy // Use cache to look up order. Caller should ensure the cache is valid.
     {
     };
-    class UpdateCachePolicy // < Use cache to look up order. Cache will be re-built if invalid.
+    class ROCROLLER_DECLSPEC
+        UpdateCachePolicy // < Use cache to look up order. Cache will be re-built if invalid.
     {
     };
-    class UseCacheIfAvailablePolicy // < Look up in cache if available, otherwise, use traversal.
+    class ROCROLLER_DECLSPEC
+        UseCacheIfAvailablePolicy // < Look up in cache if available, otherwise, use traversal.
     {
     };
-    class IgnoreCachePolicy // < Use traversal.
+    class ROCROLLER_DECLSPEC IgnoreCachePolicy // < Use traversal.
     {
     };
 

--- a/lib/include/rocRoller/KernelGraph/RegisterTagManager.hpp
+++ b/lib/include/rocRoller/KernelGraph/RegisterTagManager.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <map>
 #include <memory>
 
@@ -42,7 +44,7 @@ namespace rocRoller
      *
      * See also: LoadStoreTileGenerator::generateStride.
      */
-    struct RegisterExpressionAttributes
+    struct ROCROLLER_DECLSPEC RegisterExpressionAttributes
     {
         DataType dataType   = DataType::None; //< Desired result type of the expression
         bool     unitStride = false; //< Expression corresponds to a unitary (=1) element-stride.
@@ -54,7 +56,7 @@ namespace rocRoller
 
         auto operator<=>(RegisterExpressionAttributes const& other) const = default;
     };
-    std::string toString(RegisterExpressionAttributes const& attrs);
+    ROCROLLER_DECLSPEC std::string toString(RegisterExpressionAttributes const& attrs);
 
     /**
      * @brief Register Tag Manager - Keeps track of data flow tags
@@ -71,7 +73,7 @@ namespace rocRoller
      * using the associated data flow tag.
      *
      */
-    class RegisterTagManager
+    class ROCROLLER_DECLSPEC RegisterTagManager
     {
     public:
         RegisterTagManager(ContextPtr context);

--- a/lib/include/rocRoller/KernelGraph/RegisterTagManager_fwd.hpp
+++ b/lib/include/rocRoller/KernelGraph/RegisterTagManager_fwd.hpp
@@ -28,11 +28,13 @@
  */
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 namespace rocRoller
 {
-    class RegisterTagManager;
+    class ROCROLLER_DECLSPEC RegisterTagManager;
 
     using RegTagManPtr = std::shared_ptr<RegisterTagManager>;
 }

--- a/lib/include/rocRoller/KernelGraph/Reindexer.hpp
+++ b/lib/include/rocRoller/KernelGraph/Reindexer.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <map>
 
 #include <rocRoller/Expression_fwd.hpp>
@@ -35,7 +37,7 @@ namespace rocRoller
 {
     namespace KernelGraph
     {
-        class GraphReindexer
+        class ROCROLLER_DECLSPEC GraphReindexer
         {
         public:
             std::map<int, int> coordinates;
@@ -52,9 +54,10 @@ namespace rocRoller
          *   auto newExpr = reindexExpression(oldExpr, reindexer);
          *
          */
-        Expression::ExpressionPtr reindexExpression(Expression::ExpressionPtr expr,
-                                                    GraphReindexer const&     reindexer);
+        ROCROLLER_DECLSPEC Expression::ExpressionPtr
+            reindexExpression(Expression::ExpressionPtr expr, GraphReindexer const& reindexer);
 
-        void reindexExpressions(KernelGraph& graph, int tag, GraphReindexer const& reindexer);
+        ROCROLLER_DECLSPEC void
+            reindexExpressions(KernelGraph& graph, int tag, GraphReindexer const& reindexer);
     }
 }

--- a/lib/include/rocRoller/KernelGraph/ScopeManager.hpp
+++ b/lib/include/rocRoller/KernelGraph/ScopeManager.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 #include <unordered_set>
 #include <vector>
@@ -55,7 +57,7 @@ namespace rocRoller::KernelGraph
      * register already exists.  If not, the register is added to the
      * current scope.
      */
-    class ScopeManager
+    class ROCROLLER_DECLSPEC ScopeManager
     {
     public:
         ScopeManager() = delete;

--- a/lib/include/rocRoller/KernelGraph/ScopeManager_fwd.hpp
+++ b/lib/include/rocRoller/KernelGraph/ScopeManager_fwd.hpp
@@ -26,7 +26,9 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller::KernelGraph
 {
-    class ScopeManager;
+    class ROCROLLER_DECLSPEC ScopeManager;
 }

--- a/lib/include/rocRoller/KernelGraph/StructUtils.hpp
+++ b/lib/include/rocRoller/KernelGraph/StructUtils.hpp
@@ -26,8 +26,10 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #define RR_EMPTY_STRUCT_WITH_NAME(cls)          \
-    struct cls                                  \
+    struct ROCROLLER_DECLSPEC cls               \
     {                                           \
         static constexpr bool HasValue = false; \
                                                 \

--- a/lib/include/rocRoller/KernelGraph/Transforms/AddComputeIndex.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/AddComputeIndex.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -48,7 +50,7 @@ namespace rocRoller
          * portion of the Coordinate graph to keep track of the data
          * needed to perform the operations.
          */
-        class AddComputeIndex : public GraphTransform
+        class ROCROLLER_DECLSPEC AddComputeIndex : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;

--- a/lib/include/rocRoller/KernelGraph/Transforms/AddConvert.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/AddConvert.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -38,7 +40,7 @@ namespace rocRoller
          * datatype of the arguments to the multiply and adds control
          * nodes that will perform the appropriate type conversion.
          */
-        class AddConvert : public GraphTransform
+        class ROCROLLER_DECLSPEC AddConvert : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;

--- a/lib/include/rocRoller/KernelGraph/Transforms/AddDeallocate.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/AddDeallocate.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -38,7 +40,7 @@ namespace rocRoller
          * lifetimes.  Deallocate operations are added when registers
          * are no longer needed.
          */
-        class AddDeallocate : public GraphTransform
+        class ROCROLLER_DECLSPEC AddDeallocate : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;

--- a/lib/include/rocRoller/KernelGraph/Transforms/AddDirect2LDS.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/AddDirect2LDS.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -36,7 +38,7 @@ namespace rocRoller
          *
      * @ingroup Transformations
     */
-        class AddDirect2LDS : public GraphTransform
+        class ROCROLLER_DECLSPEC AddDirect2LDS : public GraphTransform
         {
         public:
             AddDirect2LDS(ContextPtr context, CommandParametersPtr params)

--- a/lib/include/rocRoller/KernelGraph/Transforms/AddF6LDSPadding.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/AddF6LDSPadding.hpp
@@ -25,8 +25,10 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -51,7 +53,7 @@ namespace rocRoller
          *     transpose loads have their new needsPadding field set to indicate
          *     to CodeGen that padding is required.
          */
-        class AddF6LDSPadding : public GraphTransform
+        class ROCROLLER_DECLSPEC AddF6LDSPadding : public GraphTransform
         {
         public:
             AddF6LDSPadding(ContextPtr context)

--- a/lib/include/rocRoller/KernelGraph/Transforms/AddLDS.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/AddLDS.hpp
@@ -25,8 +25,10 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -48,7 +50,7 @@ namespace rocRoller
          *
          * @ingroup Transformations
          */
-        class AddLDS : public GraphTransform
+        class ROCROLLER_DECLSPEC AddLDS : public GraphTransform
         {
         public:
             AddLDS(CommandParametersPtr params, ContextPtr context)
@@ -77,7 +79,7 @@ namespace rocRoller
          * Modifies the coordinate and control graphs to add LDS
          * information.
          */
-        class AddPrefetch : public GraphTransform
+        class ROCROLLER_DECLSPEC AddPrefetch : public GraphTransform
         {
         public:
             AddPrefetch(CommandParametersPtr params, ContextPtr context)

--- a/lib/include/rocRoller/KernelGraph/Transforms/AddPRNG.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/AddPRNG.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -41,7 +43,7 @@ namespace rocRoller
          *
      * @ingroup Transformations
     */
-        class AddPRNG : public GraphTransform
+        class ROCROLLER_DECLSPEC AddPRNG : public GraphTransform
         {
         public:
             AddPRNG(ContextPtr context)

--- a/lib/include/rocRoller/KernelGraph/Transforms/AddStreamK.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/AddStreamK.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/CommandSolution_fwd.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 #include <rocRoller/CommandSolution.hpp>
 #include <rocRoller/Context_fwd.hpp>
@@ -73,7 +75,7 @@ namespace rocRoller
          *
          * @param numWGs How many workgroups will be launched.
          */
-        class AddStreamK : public GraphTransform
+        class ROCROLLER_DECLSPEC AddStreamK : public GraphTransform
         {
         public:
             AddStreamK()                  = delete;

--- a/lib/include/rocRoller/KernelGraph/Transforms/AliasDataFlowTags.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/AliasDataFlowTags.hpp
@@ -25,8 +25,10 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -59,7 +61,7 @@ namespace rocRoller
          *
          * @ingroup Transformations
          */
-        class AliasDataFlowTags : public GraphTransform
+        class ROCROLLER_DECLSPEC AliasDataFlowTags : public GraphTransform
         {
         public:
             AliasDataFlowTags() = default;

--- a/lib/include/rocRoller/KernelGraph/Transforms/AliasDataFlowTags_detail.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/AliasDataFlowTags_detail.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/KernelGraph/Transforms/AliasDataFlowTags.hpp>
 
 #include <rocRoller/KernelGraph/ControlGraph/ControlFlowRWTracer.hpp>
@@ -39,7 +41,7 @@ namespace rocRoller
             using Record = ControlFlowRWTracer::ReadWriteRecord;
             using Edge   = ControlGraph::ControlEdge;
 
-            class TagRWGraph : public Graph::Hypergraph<Record, Edge, false>
+            class ROCROLLER_DECLSPEC TagRWGraph : public Graph::Hypergraph<Record, Edge, false>
             {
                 using Base = Graph::Hypergraph<Record, Edge, false>;
                 using Base::Hypergraph;
@@ -64,7 +66,7 @@ namespace rocRoller
              * have to be after all nodes in the `begin` set and before all
              * nodes in the `end` set.
              */
-            struct GraphExtent
+            struct ROCROLLER_DECLSPEC GraphExtent
             {
                 std::set<int> begin;
                 std::set<int> end;
@@ -77,14 +79,15 @@ namespace rocRoller
                 bool isWithin(KernelGraph const& kgraph, GraphExtent const& gap) const;
             };
 
-            std::ostream& operator<<(std::ostream& stream, GraphExtent const& extent);
+            ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&      stream,
+                                                        GraphExtent const& extent);
 
             /**
              * Represents the liveness of a given tag, including any gaps
              * where it would be acceptable for the registers to be
              * modified.
              */
-            struct TagExtent
+            struct ROCROLLER_DECLSPEC TagExtent
             {
                 using CategoryKey = std::tuple<MemoryType, LayoutType, DataType, int>;
 
@@ -123,26 +126,29 @@ namespace rocRoller
              * Returns a graph describing the relative ordering of each of the
              * control nodes in `records`.
              */
-            TagRWGraph getOrdering(KernelGraph const& kgraph, std::vector<Record> const& records);
+            ROCROLLER_DECLSPEC TagRWGraph getOrdering(KernelGraph const&         kgraph,
+                                                      std::vector<Record> const& records);
 
             /**
              * Returns a TagExtent with the metadata (but not the extent or
              * gaps) filled in.
              */
-            TagExtent getInfo(KernelGraph const& kgraph, std::vector<Record> const& records);
+            ROCROLLER_DECLSPEC TagExtent getInfo(KernelGraph const&         kgraph,
+                                                 std::vector<Record> const& records);
 
             /**
              * Returns a complete TagExtent representing the usage pattern
              * recorded in `records`.
              */
-            TagExtent getExtent(KernelGraph const& kgraph, std::vector<Record> const& records);
+            ROCROLLER_DECLSPEC TagExtent getExtent(KernelGraph const&         kgraph,
+                                                   std::vector<Record> const& records);
 
             /**
              * Returns a set of aliases inner -> outer where `inner` can borrow
              * the registers of `outer` without causing a correctness problem
              * for the kernel.
              */
-            std::map<int, int> findAliasCandidates(KernelGraph const& kgraph);
+            ROCROLLER_DECLSPEC std::map<int, int> findAliasCandidates(KernelGraph const& kgraph);
 
         }
     }

--- a/lib/include/rocRoller/KernelGraph/Transforms/CleanArguments.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/CleanArguments.hpp
@@ -25,9 +25,11 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/AssemblyKernel_fwd.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
 #include <rocRoller/Operations/Command_fwd.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -37,7 +39,7 @@ namespace rocRoller
          * @brief Removes all CommandArgruments found within an
          * expression with the appropriate AssemblyKernel Argument.
          */
-        class CleanArguments : public GraphTransform
+        class ROCROLLER_DECLSPEC CleanArguments : public GraphTransform
         {
         public:
             CleanArguments(ContextPtr context, CommandPtr command)

--- a/lib/include/rocRoller/KernelGraph/Transforms/CleanLoops.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/CleanLoops.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -36,7 +38,7 @@ namespace rocRoller
          *
          * Removes forloops that only contain a single iterations.
          */
-        class CleanLoops : public GraphTransform
+        class ROCROLLER_DECLSPEC CleanLoops : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;

--- a/lib/include/rocRoller/KernelGraph/Transforms/ConnectWorkgroups.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/ConnectWorkgroups.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -39,7 +41,7 @@ namespace rocRoller
          * that are leafs (don't have outgoing/incoming edges), and
          * attaches Workgroup coordinates to them.
          */
-        class ConnectWorkgroups : public GraphTransform
+        class ROCROLLER_DECLSPEC ConnectWorkgroups : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;

--- a/lib/include/rocRoller/KernelGraph/Transforms/ConstantPropagation.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/ConstantPropagation.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
 
@@ -36,7 +38,7 @@ namespace rocRoller
         /**
          * @brief Propagate constant to prune unneeded Load and Assign operations. Only support for beta==0 for now.
          */
-        class ConstantPropagation : public GraphTransform
+        class ROCROLLER_DECLSPEC ConstantPropagation : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;

--- a/lib/include/rocRoller/KernelGraph/Transforms/FuseExpressions.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/FuseExpressions.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -36,7 +38,7 @@ namespace rocRoller
          *
          * Fuses neighbouring expressions where possible.
          */
-        class FuseExpressions : public GraphTransform
+        class ROCROLLER_DECLSPEC FuseExpressions : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;

--- a/lib/include/rocRoller/KernelGraph/Transforms/FuseLoops.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/FuseLoops.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -37,7 +39,7 @@ namespace rocRoller
          * Fuses multiple loops together if they iterate over the same
          * length.
          */
-        class FuseLoops : public GraphTransform
+        class ROCROLLER_DECLSPEC FuseLoops : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;

--- a/lib/include/rocRoller/KernelGraph/Transforms/GraphTransform.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/GraphTransform.hpp
@@ -57,6 +57,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <vector>
 
 #include <rocRoller/KernelGraph/KernelGraph.hpp>
@@ -72,7 +74,7 @@ namespace rocRoller
          * returns a transformed kernel graph based on the
          * transformation.
          */
-        class GraphTransform
+        class ROCROLLER_DECLSPEC GraphTransform
         {
         public:
             GraphTransform()                                       = default;

--- a/lib/include/rocRoller/KernelGraph/Transforms/GraphTransform_fwd.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/GraphTransform_fwd.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 #include <rocRoller/KernelGraph/KernelGraph.hpp>
@@ -34,7 +36,7 @@ namespace rocRoller
 {
     namespace KernelGraph
     {
-        class GraphTransform;
+        class ROCROLLER_DECLSPEC GraphTransform;
 
         using GraphTransformPtr = std::shared_ptr<GraphTransform>;
     }

--- a/lib/include/rocRoller/KernelGraph/Transforms/IdentifyParallelDimensions.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/IdentifyParallelDimensions.hpp
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <variant>
 #include <vector>
 
@@ -53,7 +55,8 @@ namespace rocRoller
          * This means that the output should be run through mergeSets() before
          * using.
          */
-        std::vector<std::set<int>> identifyParallelDimensionSets(KernelGraph const& graph);
+        ROCROLLER_DECLSPEC std::vector<std::set<int>>
+                           identifyParallelDimensionSets(KernelGraph const& graph);
 
         /**
          * Returns the set of LoadTiled nodes reachable from `start`
@@ -63,7 +66,7 @@ namespace rocRoller
          *
          * @param start a control node ID. Typically this should be a StoreTiled node.
          */
-        std::set<int> loadNodesReachableWithoutDimensionModifyingNodes(
+        ROCROLLER_DECLSPEC std::set<int> loadNodesReachableWithoutDimensionModifyingNodes(
             ControlGraph::ControlGraph const& graph, int start);
 
         /**
@@ -80,7 +83,7 @@ namespace rocRoller
          * predicates to the CommandKernel so that we check that these sizes are
          * consistent.
          */
-        class IdentifyParallelDimensions : public GraphTransform
+        class ROCROLLER_DECLSPEC IdentifyParallelDimensions : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;

--- a/lib/include/rocRoller/KernelGraph/Transforms/InlineIncrements.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/InlineIncrements.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -34,7 +36,7 @@ namespace rocRoller
         /**
          * @brief Moves loop-iteration operations into the loop body.
          */
-        class InlineIncrements : public GraphTransform
+        class ROCROLLER_DECLSPEC InlineIncrements : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;

--- a/lib/include/rocRoller/KernelGraph/Transforms/LoadPacked.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/LoadPacked.hpp
@@ -25,14 +25,16 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
     namespace KernelGraph
     {
-        class LoadPacked : public GraphTransform
+        class ROCROLLER_DECLSPEC LoadPacked : public GraphTransform
         {
         public:
             LoadPacked(ContextPtr context);

--- a/lib/include/rocRoller/KernelGraph/Transforms/LoopOverTileNumbers.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/LoopOverTileNumbers.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <vector>
 
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
@@ -82,7 +84,7 @@ namespace rocRoller
          *
          *    Launched workgroups = product(tileNumberCoordSizes) * numIteratedTiles
          */
-        class LoopOverTileNumbers : public GraphTransform
+        class ROCROLLER_DECLSPEC LoopOverTileNumbers : public GraphTransform
         {
         public:
             LoopOverTileNumbers() = delete;

--- a/lib/include/rocRoller/KernelGraph/Transforms/LowerLinear.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/LowerLinear.hpp
@@ -25,9 +25,11 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/Expression_fwd.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -41,7 +43,7 @@ namespace rocRoller
          * Linear dimensions are packed/flattened, tiled onto
          * workgroups and wavefronts, and then operated on.
          */
-        class LowerLinear : public GraphTransform
+        class ROCROLLER_DECLSPEC LowerLinear : public GraphTransform
         {
         public:
             LowerLinear(ContextPtr context)
@@ -62,7 +64,7 @@ namespace rocRoller
         /**
          * Rewrite KernelGraph to additionally distribute linear dimensions onto a For loop.
          */
-        class LowerLinearLoop : public GraphTransform
+        class ROCROLLER_DECLSPEC LowerLinearLoop : public GraphTransform
         {
         public:
             LowerLinearLoop(Expression::ExpressionPtr loopSize, ContextPtr context)

--- a/lib/include/rocRoller/KernelGraph/Transforms/LowerTensorContraction.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/LowerTensorContraction.hpp
@@ -25,9 +25,11 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/CommandSolution.hpp>
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -39,7 +41,7 @@ namespace rocRoller
          * Currently supports matrix-matrix products.  The contraction
          * is lowered using a "data-parallel" decomposition.
          */
-        class LowerTensorContraction : public GraphTransform
+        class ROCROLLER_DECLSPEC LowerTensorContraction : public GraphTransform
         {
         public:
             LowerTensorContraction(CommandParametersPtr params, ContextPtr context)

--- a/lib/include/rocRoller/KernelGraph/Transforms/LowerTile.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/LowerTile.hpp
@@ -25,9 +25,11 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/CommandSolution.hpp>
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -50,7 +52,7 @@ namespace rocRoller
          * translation time.  To specify these attributes, call
          * `setDimension`.
          */
-        class LowerTile : public GraphTransform
+        class ROCROLLER_DECLSPEC LowerTile : public GraphTransform
         {
         public:
             LowerTile(CommandParametersPtr params, ContextPtr context)

--- a/lib/include/rocRoller/KernelGraph/Transforms/OrderEpilogueBlocks.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/OrderEpilogueBlocks.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -36,7 +38,7 @@ namespace rocRoller
          *
          * Orders the epilogue components.
          */
-        class OrderEpilogueBlocks : public GraphTransform
+        class ROCROLLER_DECLSPEC OrderEpilogueBlocks : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;

--- a/lib/include/rocRoller/KernelGraph/Transforms/OrderMemory.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/OrderMemory.hpp
@@ -25,9 +25,11 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/AssemblyKernel_fwd.hpp>
 #include <rocRoller/KernelGraph/ControlGraph/Operation.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -42,7 +44,7 @@ namespace rocRoller
         /**
          * @brief Ensure there are no ambiguous memory operations in the control graph.
          */
-        class OrderMemory : public GraphTransform
+        class ROCROLLER_DECLSPEC OrderMemory : public GraphTransform
         {
         public:
             OrderMemory(bool checkOrder = true)

--- a/lib/include/rocRoller/KernelGraph/Transforms/RemoveDuplicates.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/RemoveDuplicates.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -34,7 +36,7 @@ namespace rocRoller
         /**
          * @brief Remove duplicate loads and stores from the graph.
          */
-        class RemoveDuplicates : public GraphTransform
+        class ROCROLLER_DECLSPEC RemoveDuplicates : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;

--- a/lib/include/rocRoller/KernelGraph/Transforms/Simplify.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/Simplify.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
 
@@ -36,15 +38,15 @@ namespace rocRoller
         /**
          * @brief Simplify a graph by removing redundant edges.
          */
-        class Simplify : public GraphTransform
+        class ROCROLLER_DECLSPEC Simplify : public GraphTransform
         {
         public:
             KernelGraph apply(KernelGraph const& original) override;
             std::string name() const override;
         };
 
-        void removeRedundantSequenceEdges(KernelGraph& graph);
-        void removeRedundantBodyEdges(KernelGraph& graph);
-        void removeRedundantNOPs(KernelGraph& graph);
+        ROCROLLER_DECLSPEC void removeRedundantSequenceEdges(KernelGraph& graph);
+        ROCROLLER_DECLSPEC void removeRedundantBodyEdges(KernelGraph& graph);
+        ROCROLLER_DECLSPEC void removeRedundantNOPs(KernelGraph& graph);
     }
 }

--- a/lib/include/rocRoller/KernelGraph/Transforms/SwizzleScale.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/SwizzleScale.hpp
@@ -25,8 +25,10 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/CommandSolution.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -35,7 +37,7 @@ namespace rocRoller
         /**
          * @brief Swizzle the scale loads.
          */
-        class SwizzleScale : public GraphTransform
+        class ROCROLLER_DECLSPEC SwizzleScale : public GraphTransform
         {
         public:
             SwizzleScale(CommandParametersPtr params, ContextPtr context)

--- a/lib/include/rocRoller/KernelGraph/Transforms/UnrollLoops.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/UnrollLoops.hpp
@@ -25,7 +25,9 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/CommandSolution_fwd.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 #include <rocRoller/Context_fwd.hpp>
 #include <rocRoller/KernelGraph/Reindexer.hpp>
@@ -43,7 +45,7 @@ namespace rocRoller
          * @param start
          * @return std::string
          */
-        std::string getForLoopName(KernelGraph& graph, int start);
+        ROCROLLER_DECLSPEC std::string getForLoopName(KernelGraph& graph, int start);
 
         /**
          * @brief Determine how many times to unroll the loop.
@@ -51,7 +53,7 @@ namespace rocRoller
          * A value of 0 or 1 means do not unroll it.
          * Use getForLoopName to determine which forLoop we are attempting to unroll
          */
-        unsigned int
+        ROCROLLER_DECLSPEC unsigned int
             getUnrollAmount(KernelGraph& graph, int loopTag, CommandParametersPtr const& params);
 
         /**
@@ -60,7 +62,7 @@ namespace rocRoller
          * Unrolls every loop that does not have a previous iteration
          * dependency by a value of 2.
          */
-        class UnrollLoops : public GraphTransform
+        class ROCROLLER_DECLSPEC UnrollLoops : public GraphTransform
         {
         public:
             UnrollLoops(CommandParametersPtr params, ContextPtr context);

--- a/lib/include/rocRoller/KernelGraph/Transforms/UpdateParameters.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/UpdateParameters.hpp
@@ -25,8 +25,10 @@
  *******************************************************************************/
 
 #pragma once
+
 #include <rocRoller/CommandSolution.hpp>
 #include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+#include <rocRoller/rocRoller.hpp>
 
 namespace rocRoller
 {
@@ -36,7 +38,7 @@ namespace rocRoller
          * @brief Updates dimension parameters within the coordinate
          * graph based on the command parameters.
          */
-        class UpdateParameters : public GraphTransform
+        class ROCROLLER_DECLSPEC UpdateParameters : public GraphTransform
         {
         public:
             UpdateParameters(CommandParametersPtr params)
@@ -54,7 +56,7 @@ namespace rocRoller
             CommandParametersPtr m_params;
         };
 
-        class UpdateWavefrontParameters : public GraphTransform
+        class ROCROLLER_DECLSPEC UpdateWavefrontParameters : public GraphTransform
         {
         public:
             UpdateWavefrontParameters(CommandParametersPtr params)
@@ -72,7 +74,7 @@ namespace rocRoller
             CommandParametersPtr m_params;
         };
 
-        class SetWorkitemCount : public GraphTransform
+        class ROCROLLER_DECLSPEC SetWorkitemCount : public GraphTransform
         {
         public:
             SetWorkitemCount(ContextPtr context)

--- a/lib/include/rocRoller/KernelGraph/Utils.hpp
+++ b/lib/include/rocRoller/KernelGraph/Utils.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <functional>
 #include <optional>
 
@@ -38,7 +40,7 @@ namespace rocRoller
     namespace KernelGraph
     {
         // Return value of colourByUnrollValue.  A colour-mapping is...
-        struct UnrollColouring
+        struct ROCROLLER_DECLSPEC UnrollColouring
         {
             std::map<int, std::map<int, int>>
                 operationColour; //< Mapping: operation tag to colour-mapping.
@@ -47,51 +49,50 @@ namespace rocRoller
             std::set<int> separators; //< Separator edges in the control graph
         };
 
-        std::string toString(UnrollColouring const&);
+        ROCROLLER_DECLSPEC std::string toString(UnrollColouring const&);
 
         /**
          * @brief
          */
-        UnrollColouring colourByUnrollValue(KernelGraph const&             kgraph,
-                                            int                            topOp   = -1,
-                                            std::unordered_set<int> const& exclude = {});
+        ROCROLLER_DECLSPEC UnrollColouring colourByUnrollValue(
+            KernelGraph const& kgraph, int topOp = -1, std::unordered_set<int> const& exclude = {});
 
         /**
         * @brief Return DataFlowTag of LHS of binary expression in Assign node.
         */
         template <Expression::CBinary T>
-        std::tuple<int, Expression::ExpressionPtr> getBinaryLHS(KernelGraph const& kgraph,
-                                                                int                assign);
+        ROCROLLER_DECLSPEC std::tuple<int, Expression::ExpressionPtr>
+                           getBinaryLHS(KernelGraph const& kgraph, int assign);
 
         /**
         * @brief Return DataFlowTag of RHS of binary expression in Assign node.
         */
         template <Expression::CBinary T>
-        std::tuple<int, Expression::ExpressionPtr> getBinaryRHS(KernelGraph const& kgraph,
-                                                                int                assign);
+        ROCROLLER_DECLSPEC std::tuple<int, Expression::ExpressionPtr>
+                           getBinaryRHS(KernelGraph const& kgraph, int assign);
 
         /**
          * @brief Create a range-based for loop.
          *
          * returns {dimension, operation}
          */
-        std::pair<int, int> rangeFor(KernelGraph&              graph,
-                                     Expression::ExpressionPtr size,
-                                     const std::string&        name,
-                                     VariableType              vtype        = DataType::None,
-                                     int                       forLoopCoord = -1);
+        ROCROLLER_DECLSPEC std::pair<int, int> rangeFor(KernelGraph&              graph,
+                                                        Expression::ExpressionPtr size,
+                                                        const std::string&        name,
+                                                        VariableType vtype        = DataType::None,
+                                                        int          forLoopCoord = -1);
 
         /**
          * @brief Remove a range-based for loop created by rangeFor.
          */
-        void purgeFor(KernelGraph& graph, int tag);
+        ROCROLLER_DECLSPEC void purgeFor(KernelGraph& graph, int tag);
 
         /**
          * @brief Create a clone of a ForLoopOp. This new ForLoopOp
          * will use the same ForLoop Dimension as the original
          * ForLoopOp.
         */
-        int cloneForLoop(KernelGraph& graph, int tag);
+        ROCROLLER_DECLSPEC int cloneForLoop(KernelGraph& graph, int tag);
 
         /**
          * @brief Remove a node and all of its children from the control graph
@@ -101,21 +102,21 @@ namespace rocRoller
          * @param kgraph
          * @param node
          */
-        void purgeNodeAndChildren(KernelGraph& kgraph, int node);
+        ROCROLLER_DECLSPEC void purgeNodeAndChildren(KernelGraph& kgraph, int node);
 
         template <std::ranges::forward_range Range = std::initializer_list<int>>
-        void purgeNodes(KernelGraph& kgraph, Range nodes);
+        ROCROLLER_DECLSPEC void purgeNodes(KernelGraph& kgraph, Range nodes);
 
-        bool isHardwareCoordinate(int tag, KernelGraph const& kgraph);
-        bool isLoopishCoordinate(int tag, KernelGraph const& kgraph);
-        bool isStorageCoordinate(int tag, KernelGraph const& kgraph);
+        ROCROLLER_DECLSPEC bool isHardwareCoordinate(int tag, KernelGraph const& kgraph);
+        ROCROLLER_DECLSPEC bool isLoopishCoordinate(int tag, KernelGraph const& kgraph);
+        ROCROLLER_DECLSPEC bool isStorageCoordinate(int tag, KernelGraph const& kgraph);
 
         /**
          * @brief Filter coordinates by type.
          */
         template <typename T>
-        std::unordered_set<int> filterCoordinates(auto const&        candidates,
-                                                  KernelGraph const& kgraph);
+        ROCROLLER_DECLSPEC std::unordered_set<int> filterCoordinates(auto const&        candidates,
+                                                                     KernelGraph const& kgraph);
 
         /**
          * @brief Find storage neighbour in either direction.
@@ -128,19 +129,20 @@ namespace rocRoller
          *
          * Tries upstream first.
          */
-        std::optional<std::pair<int, Graph::Direction>>
-            findStorageNeighbour(int tag, KernelGraph const& kgraph);
+        ROCROLLER_DECLSPEC std::optional<std::pair<int, Graph::Direction>>
+                           findStorageNeighbour(int tag, KernelGraph const& kgraph);
 
         /**
          * @brief Return Unroll coordinate beside (as part of a Split
          * edge) the ForLoop coordinate.
          */
-        std::optional<int> findUnrollNeighbour(KernelGraph const& kgraph, int forLoopCoord);
+        ROCROLLER_DECLSPEC std::optional<int> findUnrollNeighbour(KernelGraph const& kgraph,
+                                                                  int                forLoopCoord);
 
         /**
         * @brief Return DataFlowTag of DEST of Assign node.
         */
-        int getDEST(KernelGraph const& kgraph, int assign);
+        ROCROLLER_DECLSPEC int getDEST(KernelGraph const& kgraph, int assign);
 
         /**
          * @brief Return target coordinate for load/store operation.
@@ -151,7 +153,8 @@ namespace rocRoller
          * For stores, the target is the destination (User or LDS) of
          * the store.
          */
-        std::pair<int, Graph::Direction> getOperationTarget(int tag, KernelGraph const& kgraph);
+        ROCROLLER_DECLSPEC std::pair<int, Graph::Direction>
+                           getOperationTarget(int tag, KernelGraph const& kgraph);
 
         /**
          * Returns the true coordinate that should be the target of a
@@ -160,7 +163,7 @@ namespace rocRoller
          * For now this will just follow any Duplicate edge leaving
          * `storageTarget`.
          */
-        int getTransformTarget(int storageTarget, KernelGraph const& kgraph);
+        ROCROLLER_DECLSPEC int getTransformTarget(int storageTarget, KernelGraph const& kgraph);
 
         /**
          * @brief Find all required coordintes needed to compute
@@ -169,30 +172,33 @@ namespace rocRoller
          * @return Pair of: vector required coordinates; set of
          * coordinates in the connecting path.
          */
-        std::pair<std::vector<int>, std::unordered_set<int>> findRequiredCoordinates(
-            int target, Graph::Direction direction, KernelGraph const& kgraph);
+        ROCROLLER_DECLSPEC std::pair<std::vector<int>, std::unordered_set<int>>
+                           findRequiredCoordinates(int                target,
+                                                   Graph::Direction   direction,
+                                                   KernelGraph const& kgraph);
 
-        std::pair<std::vector<int>, std::unordered_set<int>>
-            findRequiredCoordinates(int                      target,
-                                    Graph::Direction         direction,
-                                    std::function<bool(int)> fullStop,
-                                    KernelGraph const&       kgraph);
+        ROCROLLER_DECLSPEC std::pair<std::vector<int>, std::unordered_set<int>>
+                           findRequiredCoordinates(int                      target,
+                                                   Graph::Direction         direction,
+                                                   std::function<bool(int)> fullStop,
+                                                   KernelGraph const&       kgraph);
 
-        std::pair<std::unordered_set<int>, std::unordered_set<int>>
-            findAllRequiredCoordinates(int op, KernelGraph const& graph);
+        ROCROLLER_DECLSPEC std::pair<std::unordered_set<int>, std::unordered_set<int>>
+                           findAllRequiredCoordinates(int op, KernelGraph const& graph);
 
         /**
          * @brief Find the operation of type T that contains the
          * candidate load/store operation.
          */
         template <typename T>
-        std::optional<int> findContainingOperation(int candidate, KernelGraph const& kgraph);
+        ROCROLLER_DECLSPEC std::optional<int> findContainingOperation(int                candidate,
+                                                                      KernelGraph const& kgraph);
 
         /**
          * @brief Reconnect incoming/outgoing edges from op to newop.
          */
         template <Graph::Direction direction>
-        void reconnect(KernelGraph& graph, int newop, int op);
+        ROCROLLER_DECLSPEC void reconnect(KernelGraph& graph, int newop, int op);
 
         /**
          * @brief Find the operation of type T that contains the
@@ -200,7 +206,8 @@ namespace rocRoller
          * body of that operation.
          */
         template <typename T>
-        std::optional<int> findTopOfContainingOperation(int candidate, KernelGraph const& kgraph);
+        ROCROLLER_DECLSPEC std::optional<int>
+                           findTopOfContainingOperation(int candidate, KernelGraph const& kgraph);
 
         /**
          * @brief Create a new coordinate representing data within the scratch space. This will return a
@@ -212,7 +219,7 @@ namespace rocRoller
          * @param context
          * @return User
          */
-        rocRoller::KernelGraph::CoordinateGraph::User newScratchCoordinate(
+        ROCROLLER_DECLSPEC rocRoller::KernelGraph::CoordinateGraph::User newScratchCoordinate(
             Expression::ExpressionPtr size, VariableType varType, ContextPtr context);
 
         /**
@@ -223,47 +230,51 @@ namespace rocRoller
          *
          * Does not delete the original operation.
          */
-        int replaceWith(KernelGraph& graph, int op, int newOp, bool includeBody = true);
+        ROCROLLER_DECLSPEC int
+            replaceWith(KernelGraph& graph, int op, int newOp, bool includeBody = true);
 
         /**
          * @brief Insert chain (from top to bottom) above operation.
          *
          * Bottom is attached to op via a Sequence edge.
          */
-        void insertBefore(KernelGraph& graph, int op, int top, int bottom);
+        ROCROLLER_DECLSPEC void insertBefore(KernelGraph& graph, int op, int top, int bottom);
 
         /**
          * @brief Insert chain (from top to bottom) above operation.
          *
          * Top is attached to op via a Sequence edge.
          */
-        void insertAfter(KernelGraph& graph, int op, int top, int bottom);
+        ROCROLLER_DECLSPEC void insertAfter(KernelGraph& graph, int op, int top, int bottom);
 
         /**
          * @brief Replace operation with a new operation.
          */
-        void insertWithBody(KernelGraph& graph, int op, int newOp);
+        ROCROLLER_DECLSPEC void insertWithBody(KernelGraph& graph, int op, int newOp);
 
         /**
          * @brief Find load/store operations that need their indexes
          * precomputed by ComputeIndex.
          */
-        std::vector<int> findComputeIndexCandidates(KernelGraph const& kgraph, int start);
+        ROCROLLER_DECLSPEC std::vector<int> findComputeIndexCandidates(KernelGraph const& kgraph,
+                                                                       int                start);
 
         /**
          * Removes all CommandArgruments found within an expression
          * with the appropriate AssemblyKernel Argument.
          */
-        Expression::ExpressionPtr cleanArguments(Expression::ExpressionPtr, AssemblyKernelPtr);
+        ROCROLLER_DECLSPEC Expression::ExpressionPtr cleanArguments(Expression::ExpressionPtr,
+                                                                    AssemblyKernelPtr);
 
         /**
          * @brief Get ForLoop and increment (Linear) dimensions
          * assciated with ForLoopOp.
          */
-        std::pair<int, int> getForLoopCoords(int forLoopOp, KernelGraph const& kgraph);
+        ROCROLLER_DECLSPEC std::pair<int, int> getForLoopCoords(int                forLoopOp,
+                                                                KernelGraph const& kgraph);
 
         template <CForwardRangeOf<int> Range>
-        std::optional<int>
+        ROCROLLER_DECLSPEC std::optional<int>
             getForLoopCoord(std::optional<int> forLoopOp, KernelGraph const& kgraph, Range within);
 
         /**
@@ -282,21 +293,21 @@ namespace rocRoller
          * @param forLoop
          * @return std::pair<ExpressionPtr, ExpressionPtr>
          */
-        std::pair<Expression::ExpressionPtr, Expression::ExpressionPtr>
-            getForLoopIncrement(KernelGraph const& graph, int forLoop);
+        ROCROLLER_DECLSPEC std::pair<Expression::ExpressionPtr, Expression::ExpressionPtr>
+                           getForLoopIncrement(KernelGraph const& graph, int forLoop);
 
-        void duplicateMacroTile(KernelGraph& graph, int tag);
+        ROCROLLER_DECLSPEC void duplicateMacroTile(KernelGraph& graph, int tag);
 
-        int duplicateControlNode(KernelGraph& graph, int tag);
+        ROCROLLER_DECLSPEC int duplicateControlNode(KernelGraph& graph, int tag);
 
         /**
          * Updates the threadtile size for enabling the use of long dword instructions
          */
-        void updateThreadTileForLongDwords(int& t_m,
-                                           int& t_n,
-                                           int  maxWidth,
-                                           uint macTileFastMovingDimSize,
-                                           int  numDwordsPerElement);
+        ROCROLLER_DECLSPEC void updateThreadTileForLongDwords(int& t_m,
+                                                              int& t_n,
+                                                              int  maxWidth,
+                                                              uint macTileFastMovingDimSize,
+                                                              int  numDwordsPerElement);
 
         /**
          * @brief Get the tag of the highest SetCoordinate directly upstream from load.
@@ -305,7 +316,7 @@ namespace rocRoller
          * @param load
          * @return int
          */
-        int getTopSetCoordinate(KernelGraph const& graph, int load);
+        ROCROLLER_DECLSPEC int getTopSetCoordinate(KernelGraph const& graph, int load);
 
         /**
          * @brief Get the unique tags of the highest SetCoordinate nodes directly upstream from each load.
@@ -314,7 +325,8 @@ namespace rocRoller
          * @param loads
          * @return std::set<int>
          */
-        std::set<int> getTopSetCoordinates(KernelGraph& graph, std::vector<int> loads);
+        ROCROLLER_DECLSPEC std::set<int> getTopSetCoordinates(KernelGraph&     graph,
+                                                              std::vector<int> loads);
 
         /**
          * @brief Get the SetCoordinate object upstream from load that sets the
@@ -325,7 +337,7 @@ namespace rocRoller
          * @param load
          * @return int
          */
-        int getSetCoordinateForDim(KernelGraph const& graph, int dim, int load);
+        ROCROLLER_DECLSPEC int getSetCoordinateForDim(KernelGraph const& graph, int dim, int load);
 
         /**
          * @brief Determine whether a matching SetCoordinate object exists upstream
@@ -337,16 +349,17 @@ namespace rocRoller
          * @param coordTag
          * @return bool
          */
-        bool hasExistingSetCoordinate(KernelGraph const& graph,
-                                      int                op,
-                                      int                coordValue,
-                                      int                coordTag);
+        ROCROLLER_DECLSPEC bool hasExistingSetCoordinate(KernelGraph const& graph,
+                                                         int                op,
+                                                         int                coordValue,
+                                                         int                coordTag);
 
         /**
          * Gets the unroll coordinate value that is set by a SetCoordinate node upstream
          * from the operation op, for the dimension unrollDim.
          */
-        unsigned int getUnrollValueForOp(KernelGraph const& graph, int unrollDim, int op);
+        ROCROLLER_DECLSPEC unsigned int
+            getUnrollValueForOp(KernelGraph const& graph, int unrollDim, int op);
 
         /**
          * @brief Create duplicates of all of the nodes downstream of the provided
@@ -362,15 +375,16 @@ namespace rocRoller
          * @return New start nodes for the duplicated sub-graph.
          */
         template <std::predicate<int> Predicate>
-        std::vector<int> duplicateControlNodes(KernelGraph&                    graph,
-                                               std::shared_ptr<GraphReindexer> reindexer,
-                                               std::vector<int> const&         startNodes,
-                                               Predicate                       dontDuplicate);
+        ROCROLLER_DECLSPEC std::vector<int>
+                           duplicateControlNodes(KernelGraph&                    graph,
+                                                 std::shared_ptr<GraphReindexer> reindexer,
+                                                 std::vector<int> const&         startNodes,
+                                                 Predicate                       dontDuplicate);
 
         /**
          * @brief Return VariableType of load/store operation.
          */
-        VariableType getVariableType(KernelGraph const& graph, int opTag);
+        ROCROLLER_DECLSPEC VariableType getVariableType(KernelGraph const& graph, int opTag);
 
         /**
          * @brief Add coordinate-transforms for storing a MacroTile
@@ -378,61 +392,62 @@ namespace rocRoller
          *
          * Implemented in LowerTile.cpp.
          */
-        void storeMacroTile_VGPR(KernelGraph&                     graph,
-                                 std::vector<DeferredConnection>& connections,
-                                 int                              userTag,
-                                 int                              macTileTag,
-                                 std::vector<int> const&          sdim,
-                                 std::vector<unsigned int> const& jammedTiles,
-                                 CommandParametersPtr             params,
-                                 ContextPtr                       context);
+        ROCROLLER_DECLSPEC void storeMacroTile_VGPR(KernelGraph&                     graph,
+                                                    std::vector<DeferredConnection>& connections,
+                                                    int                              userTag,
+                                                    int                              macTileTag,
+                                                    std::vector<int> const&          sdim,
+                                                    std::vector<unsigned int> const& jammedTiles,
+                                                    CommandParametersPtr             params,
+                                                    ContextPtr                       context);
 
         /**
          * @brief Add coordinate-transforms for loading a MacroTile
          * from global into a ThreadTile.
          */
-        void loadMacroTile_VGPR(KernelGraph&                     graph,
-                                std::vector<DeferredConnection>& connections,
-                                int                              userTag,
-                                int                              macTileTag,
-                                std::vector<int> const&          sdim,
-                                std::vector<unsigned int> const& jammedTiles,
-                                CommandParametersPtr             params,
-                                ContextPtr                       context,
-                                bool                             isDirect2LDS = false);
+        ROCROLLER_DECLSPEC void loadMacroTile_VGPR(KernelGraph&                     graph,
+                                                   std::vector<DeferredConnection>& connections,
+                                                   int                              userTag,
+                                                   int                              macTileTag,
+                                                   std::vector<int> const&          sdim,
+                                                   std::vector<unsigned int> const& jammedTiles,
+                                                   CommandParametersPtr             params,
+                                                   ContextPtr                       context,
+                                                   bool isDirect2LDS = false);
 
         /**
          * @brief Store version of addLoadThreadTileCT.
          */
-        void addStoreThreadTileCT(KernelGraph&                       graph,
-                                  std::vector<DeferredConnection>&   connections,
-                                  int                                macTileTag,
-                                  int                                iMacX,
-                                  int                                iMacY,
-                                  std::array<unsigned int, 3> const& workgroupSizes,
-                                  std::vector<unsigned int> const&   jammedTiles,
-                                  bool                               useSwappedAccess,
-                                  bool                               isDirect2LDS = false);
+        ROCROLLER_DECLSPEC void
+            addStoreThreadTileCT(KernelGraph&                       graph,
+                                 std::vector<DeferredConnection>&   connections,
+                                 int                                macTileTag,
+                                 int                                iMacX,
+                                 int                                iMacY,
+                                 std::array<unsigned int, 3> const& workgroupSizes,
+                                 std::vector<unsigned int> const&   jammedTiles,
+                                 bool                               useSwappedAccess,
+                                 bool                               isDirect2LDS = false);
 
         /**
          * @brief Store version of addLoadMacroTileCT.
          */
-        std::tuple<int, int, int, int>
-            addStoreMacroTileCT(KernelGraph&                     graph,
-                                std::vector<DeferredConnection>& connections,
-                                int                              macTileTag,
-                                std::vector<int> const&          sdim,
-                                std::vector<unsigned int> const& jammedTiles = {1, 1});
+        ROCROLLER_DECLSPEC std::tuple<int, int, int, int>
+                           addStoreMacroTileCT(KernelGraph&                     graph,
+                                               std::vector<DeferredConnection>& connections,
+                                               int                              macTileTag,
+                                               std::vector<int> const&          sdim,
+                                               std::vector<unsigned int> const& jammedTiles = {1, 1});
 
         /**
          * @brief Store version of addLoad1DMacroTileCT.
          */
-        std::tuple<int, int, int>
-            addStore1DMacroTileCT(KernelGraph&                     graph,
-                                  std::vector<DeferredConnection>& connections,
-                                  int                              macTileTag,
-                                  std::vector<int> const&          sdim,
-                                  std::vector<unsigned int> const& jammedTiles = {1, 1});
+        ROCROLLER_DECLSPEC std::tuple<int, int, int>
+                           addStore1DMacroTileCT(KernelGraph&                     graph,
+                                                 std::vector<DeferredConnection>& connections,
+                                                 int                              macTileTag,
+                                                 std::vector<int> const&          sdim,
+                                                 std::vector<unsigned int> const& jammedTiles = {1, 1});
 
         /**
          * @brief Add coordinate-transforms for tiling two
@@ -448,11 +463,11 @@ namespace rocRoller
          * @return Tuple of: row MacroTileNumber, row MacroTileIndex,
          * column MacroTileNumber, column MacroTileIndex.
          */
-        std::tuple<int, int, int, int>
-            addLoadMacroTileCT(KernelGraph&                     graph,
-                               std::vector<DeferredConnection>& connections,
-                               int                              macTileTag,
-                               std::vector<int> const&          sdim);
+        ROCROLLER_DECLSPEC std::tuple<int, int, int, int>
+                           addLoadMacroTileCT(KernelGraph&                     graph,
+                                              std::vector<DeferredConnection>& connections,
+                                              int                              macTileTag,
+                                              std::vector<int> const&          sdim);
 
         /**
          * @brief Add coordinate-transforms for tiling the X
@@ -470,10 +485,11 @@ namespace rocRoller
          * @return Tuple of: row MacroTileNumber, row MacroTileIndex,
          * column MacroTileIndex.
          */
-        std::tuple<int, int, int> addLoad1DMacroTileCT(KernelGraph&                     graph,
-                                                       std::vector<DeferredConnection>& connections,
-                                                       int                              macTileTag,
-                                                       std::vector<int> const&          sdim);
+        ROCROLLER_DECLSPEC std::tuple<int, int, int>
+                           addLoad1DMacroTileCT(KernelGraph&                     graph,
+                                                std::vector<DeferredConnection>& connections,
+                                                int                              macTileTag,
+                                                std::vector<int> const&          sdim);
 
         /**
          * @brief Add coordinate-transforms for loading a ThreadTile
@@ -498,26 +514,27 @@ namespace rocRoller
          * Required (deferred) connections are appended to
          * `connections`.
          */
-        void addLoadThreadTileCT(KernelGraph&                       graph,
-                                 std::vector<DeferredConnection>&   connections,
-                                 int                                macTileTag,
-                                 int                                iMacX,
-                                 int                                iMacY,
-                                 std::array<unsigned int, 3> const& workgroupSizes,
-                                 std::vector<unsigned int> const&   jammedTiles,
-                                 bool                               useSwappedAccess,
-                                 bool                               isDirect2LDS = false);
+        ROCROLLER_DECLSPEC void
+            addLoadThreadTileCT(KernelGraph&                       graph,
+                                std::vector<DeferredConnection>&   connections,
+                                int                                macTileTag,
+                                int                                iMacX,
+                                int                                iMacY,
+                                std::array<unsigned int, 3> const& workgroupSizes,
+                                std::vector<unsigned int> const&   jammedTiles,
+                                bool                               useSwappedAccess,
+                                bool                               isDirect2LDS = false);
 
         /**
          * @brief Create an internal tile backed by a ThreadTile.
          *
          * Implemented in LowerTile.cpp.
          */
-        int createInternalTile(KernelGraph&         graph,
-                               VariableType         varType,
-                               int                  macTileTag,
-                               CommandParametersPtr params,
-                               ContextPtr           context);
+        ROCROLLER_DECLSPEC int createInternalTile(KernelGraph&         graph,
+                                                  VariableType         varType,
+                                                  int                  macTileTag,
+                                                  CommandParametersPtr params,
+                                                  ContextPtr           context);
 
         /**
          * @brief Create an internal tile backed by a ThreadTile.  The
@@ -525,13 +542,13 @@ namespace rocRoller
          *
          * Implemented in LowerTile.cpp.
          */
-        int createInternalTile(KernelGraph&                     graph,
-                               VariableType                     varType,
-                               int                              macTileTag,
-                               std::vector<unsigned int> const& numWaveTiles,
-                               bool                             splitStore,
-                               CommandParametersPtr             params,
-                               ContextPtr                       context);
+        ROCROLLER_DECLSPEC int createInternalTile(KernelGraph&                     graph,
+                                                  VariableType                     varType,
+                                                  int                              macTileTag,
+                                                  std::vector<unsigned int> const& numWaveTiles,
+                                                  bool                             splitStore,
+                                                  CommandParametersPtr             params,
+                                                  ContextPtr                       context);
 
         /**
          * @brief Order all input pairs of memory nodes in graph.
@@ -540,9 +557,9 @@ namespace rocRoller
          * @param pairs Pairs of memory nodes to be ordered.
          * @param ordered If true, the pairs are passed in order.
          */
-        void orderMemoryNodes(KernelGraph&                         graph,
-                              std::set<std::pair<int, int>> const& pairs,
-                              bool                                 ordered);
+        ROCROLLER_DECLSPEC void orderMemoryNodes(KernelGraph&                         graph,
+                                                 std::set<std::pair<int, int>> const& pairs,
+                                                 bool                                 ordered);
 
         /**
          * @brief Order all memory nodes in srcs with respect to all memory nodes in dests.
@@ -552,10 +569,10 @@ namespace rocRoller
          * @param dests
          * @param ordered If true, all orderings will be src -> dest.
          */
-        void orderMemoryNodes(KernelGraph&         graph,
-                              std::set<int> const& srcs,
-                              std::set<int> const& dests,
-                              bool                 ordered);
+        ROCROLLER_DECLSPEC void orderMemoryNodes(KernelGraph&         graph,
+                                                 std::set<int> const& srcs,
+                                                 std::set<int> const& dests,
+                                                 bool                 ordered);
 
         /**
          * @brief Order all input nodes with respect to each other.
@@ -564,16 +581,17 @@ namespace rocRoller
          * @param nodes
          * @param ordered If true, all orderings will be nodes[i-1] -> nodes[i].
          */
-        void orderMemoryNodes(KernelGraph& graph, std::vector<int> const& nodes, bool ordered);
+        ROCROLLER_DECLSPEC void
+            orderMemoryNodes(KernelGraph& graph, std::vector<int> const& nodes, bool ordered);
 
         /**
          * Replace the use of an old macrotile in the given control
          * nodes with a new macrotile.
          */
-        void replaceMacroTile(KernelGraph&                   graph,
-                              std::unordered_set<int> const& ops,
-                              int                            oldMacTileTag,
-                              int                            newMacTileTag);
+        ROCROLLER_DECLSPEC void replaceMacroTile(KernelGraph&                   graph,
+                                                 std::unordered_set<int> const& ops,
+                                                 int                            oldMacTileTag,
+                                                 int                            newMacTileTag);
 
         /**
          * @brief
@@ -583,7 +601,8 @@ namespace rocRoller
          * @param opTag2 LoadTileDirect2LDS operation
          *
          */
-        void moveConnections(rocRoller::KernelGraph::KernelGraph& kgraph, int opTag1, int opTag2);
+        ROCROLLER_DECLSPEC void
+            moveConnections(rocRoller::KernelGraph::KernelGraph& kgraph, int opTag1, int opTag2);
 
         /**
         * @brief ceil(a/b) = (a+b-1)/b
@@ -592,7 +611,8 @@ namespace rocRoller
         * @param tileSize MacroTile size
         *
         */
-        Expression::ExpressionPtr tileCeilDivide(Expression::ExpressionPtr sdSize, int tileSize);
+        ROCROLLER_DECLSPEC Expression::ExpressionPtr
+                           tileCeilDivide(Expression::ExpressionPtr sdSize, int tileSize);
 
         /**
         * @brief Identifies whether a registerTag has an associated deallocate node.
@@ -601,7 +621,7 @@ namespace rocRoller
         * @param registerTag
         *
         */
-        bool hasDeallocate(const KernelGraph& graph, int tag);
+        ROCROLLER_DECLSPEC bool hasDeallocate(const KernelGraph& graph, int tag);
     }
 }
 

--- a/lib/include/rocRoller/KernelGraph/Visitors.hpp
+++ b/lib/include/rocRoller/KernelGraph/Visitors.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <iostream>
 #include <memory>
 #include <set>
@@ -126,7 +128,7 @@ namespace rocRoller
          * To rewrite, for example, only LoadLinear edges, simply
          * override the `visitEdge` method.
          */
-        struct BaseGraphVisitor
+        struct ROCROLLER_DECLSPEC BaseGraphVisitor
         {
             BaseGraphVisitor(ContextPtr       context,
                              Graph::Direction controlGraphOrder  = Graph::Direction::Downstream,

--- a/lib/include/rocRoller/KernelOptions.hpp
+++ b/lib/include/rocRoller/KernelOptions.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <ostream>
 #include <string>
 
@@ -42,7 +44,7 @@ namespace rocRoller
     const std::string SCRATCH = "SCRATCH";
     const std::string NUMWGS  = "numWGs";
 
-    struct KernelOptions
+    struct ROCROLLER_DECLSPEC KernelOptions
     {
         LogLevel logLevel = LogLevel::Verbose;
 

--- a/lib/include/rocRoller/Operations/BlockScale.hpp
+++ b/lib/include/rocRoller/Operations/BlockScale.hpp
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <optional>
 #include <unordered_set>
 #include <vector>
@@ -45,7 +47,7 @@ namespace rocRoller
         /**
          * A block scale operation for MX datatypes
         */
-        class BlockScale : public BaseOperation
+        class ROCROLLER_DECLSPEC BlockScale : public BaseOperation
         {
         public:
             BlockScale() = delete;

--- a/lib/include/rocRoller/Operations/BlockScale_fwd.hpp
+++ b/lib/include/rocRoller/Operations/BlockScale_fwd.hpp
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 
 namespace rocRoller
@@ -39,7 +41,7 @@ namespace rocRoller
         /**
          * A block scale operation for MX datatypes
         */
-        class BlockScale;
+        class ROCROLLER_DECLSPEC BlockScale;
 
         enum class ScaleMode
         {
@@ -50,8 +52,8 @@ namespace rocRoller
             Count
         };
 
-        std::string   toString(ScaleMode const& mode);
-        std::ostream& operator<<(std::ostream& stream, ScaleMode const& mode);
+        ROCROLLER_DECLSPEC std::string toString(ScaleMode const& mode);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, ScaleMode const& mode);
 
     }
 }

--- a/lib/include/rocRoller/Operations/Command.hpp
+++ b/lib/include/rocRoller/Operations/Command.hpp
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <map>
 #include <memory>
 #include <vector>
@@ -43,7 +45,7 @@
 namespace rocRoller
 {
 
-    struct Command : public std::enable_shared_from_this<Command>
+    struct ROCROLLER_DECLSPEC Command : public std::enable_shared_from_this<Command>
     {
     public:
         using OperationList = std::vector<std::shared_ptr<Operations::Operation>>;
@@ -145,7 +147,7 @@ namespace rocRoller
         int m_runtimeArgsOffset = 0;
     };
 
-    std::ostream& operator<<(std::ostream& stream, Command const& command);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, Command const& command);
 
 }
 

--- a/lib/include/rocRoller/Operations/CommandArgument.hpp
+++ b/lib/include/rocRoller/Operations/CommandArgument.hpp
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <optional>
 #include <string>
 
@@ -56,7 +58,7 @@ namespace rocRoller
      * specific value or type of value should be implemented through
      * the predication mechanism.
      */
-    class CommandArgument : public std::enable_shared_from_this<CommandArgument>
+    class ROCROLLER_DECLSPEC CommandArgument : public std::enable_shared_from_this<CommandArgument>
     {
     public:
         CommandArgument(CommandPtr    com,
@@ -100,25 +102,26 @@ namespace rocRoller
         std::string   m_name;
     };
 
-    std::ostream& operator<<(std::ostream&, CommandArgument const&);
-    std::ostream& operator<<(std::ostream&, CommandArgumentPtr const&);
-    std::ostream& operator<<(std::ostream&, std::vector<CommandArgumentPtr> const&);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, CommandArgument const&);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, CommandArgumentPtr const&);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&,
+                                                std::vector<CommandArgumentPtr> const&);
 
-    VariableType  variableType(CommandArgumentValue const& val);
-    std::string   name(CommandArgumentValue const& val);
-    std::string   toString(CommandArgumentValue const& val);
-    std::ostream& operator<<(std::ostream&, CommandArgumentValue const&);
+    ROCROLLER_DECLSPEC VariableType variableType(CommandArgumentValue const& val);
+    ROCROLLER_DECLSPEC std::string name(CommandArgumentValue const& val);
+    ROCROLLER_DECLSPEC std::string toString(CommandArgumentValue const& val);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, CommandArgumentValue const&);
 
     /**
      * Returns an unsigned integer from a CommandArgumentValue.
      * If the CommandArgumentValue is not an integer, an exception will be thrown.
      */
-    unsigned int getUnsignedInt(CommandArgumentValue val);
+    ROCROLLER_DECLSPEC unsigned int getUnsignedInt(CommandArgumentValue val);
 
     /**
      * Returns true if a CommandArgumentValue is an integer type.
      */
-    bool isInteger(CommandArgumentValue val);
+    ROCROLLER_DECLSPEC bool isInteger(CommandArgumentValue val);
 }
 
 #include <rocRoller/Operations/CommandArgument_impl.hpp>

--- a/lib/include/rocRoller/Operations/CommandArgument_fwd.hpp
+++ b/lib/include/rocRoller/Operations/CommandArgument_fwd.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 #include <span>
 #include <variant>
@@ -34,7 +36,7 @@
 
 namespace rocRoller
 {
-    class CommandArgument;
+    class ROCROLLER_DECLSPEC CommandArgument;
     using CommandArgumentPtr = std::shared_ptr<CommandArgument>;
 
     using CommandArgumentValue = std::variant<

--- a/lib/include/rocRoller/Operations/CommandArguments.hpp
+++ b/lib/include/rocRoller/Operations/CommandArguments.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/KernelArguments.hpp>
 #include <rocRoller/Operations/CommandArgument_fwd.hpp>
 #include <rocRoller/Operations/CommandArguments_fwd.hpp>
@@ -33,10 +35,10 @@
 
 namespace rocRoller
 {
-    std::string   toString(ArgumentType);
-    std::ostream& operator<<(std::ostream&, ArgumentType);
+    ROCROLLER_DECLSPEC std::string toString(ArgumentType);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, ArgumentType);
 
-    class CommandArguments
+    class ROCROLLER_DECLSPEC CommandArguments
     {
     public:
         CommandArguments() = delete;

--- a/lib/include/rocRoller/Operations/Command_fwd.hpp
+++ b/lib/include/rocRoller/Operations/Command_fwd.hpp
@@ -29,13 +29,15 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <iostream>
 #include <memory>
 
 namespace rocRoller
 {
-    class Command;
+    class ROCROLLER_DECLSPEC Command;
     using CommandPtr = std::shared_ptr<Command>;
 
-    std::ostream& operator<<(std::ostream& stream, Command const& command);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, Command const& command);
 }

--- a/lib/include/rocRoller/Operations/Operation.hpp
+++ b/lib/include/rocRoller/Operations/Operation.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Operations/Command_fwd.hpp>
 #include <rocRoller/Operations/OperationTag.hpp>
 #include <rocRoller/Serialization/Base_fwd.hpp>
@@ -36,7 +38,7 @@ namespace rocRoller
 {
     namespace Operations
     {
-        class BaseOperation
+        class ROCROLLER_DECLSPEC BaseOperation
         {
         public:
             BaseOperation();

--- a/lib/include/rocRoller/Operations/OperationTag.hpp
+++ b/lib/include/rocRoller/Operations/OperationTag.hpp
@@ -26,13 +26,15 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/DataTypes/DistinctType.hpp>
 
 namespace rocRoller
 {
     namespace Operations
     {
-        struct OperationTag final : public DistinctType<int32_t, OperationTag>
+        struct ROCROLLER_DECLSPEC OperationTag final : public DistinctType<int32_t, OperationTag>
         {
             explicit OperationTag(int value)
                 : DistinctType<int32_t, OperationTag>(value)

--- a/lib/include/rocRoller/Operations/Operations.hpp
+++ b/lib/include/rocRoller/Operations/Operations.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <unordered_set>
 
 #include <rocRoller/Context_fwd.hpp>
@@ -44,7 +46,7 @@ namespace rocRoller
 {
     namespace Operations
     {
-        struct Nop
+        struct ROCROLLER_DECLSPEC Nop
         {
             Nop() {}
             template <typename... Args>
@@ -55,7 +57,7 @@ namespace rocRoller
             auto operator<=>(Nop const&) const = default;
         };
 
-        struct Inputs
+        struct ROCROLLER_DECLSPEC Inputs
         {
             std::unordered_set<OperationTag> call(Operation const&);
 
@@ -79,7 +81,7 @@ namespace rocRoller
             std::unordered_set<OperationTag> operator()(Nop const&);
         };
 
-        struct Outputs
+        struct ROCROLLER_DECLSPEC Outputs
         {
             std::unordered_set<OperationTag> call(Operation const&);
 
@@ -103,7 +105,7 @@ namespace rocRoller
             std::unordered_set<OperationTag> operator()(Nop const&);
         };
 
-        struct TagVisitor
+        struct ROCROLLER_DECLSPEC TagVisitor
         {
             OperationTag call(XOp const&);
             OperationTag operator()(E_Unary const&);
@@ -111,7 +113,7 @@ namespace rocRoller
             OperationTag operator()(E_Ternary const&);
         };
 
-        struct AssignOutputs
+        struct ROCROLLER_DECLSPEC AssignOutputs
         {
             std::unordered_set<OperationTag> call(Operation&, OperationTag);
 
@@ -138,7 +140,7 @@ namespace rocRoller
             OperationTag m_nextTagValue;
         };
 
-        struct ToStringVisitor
+        struct ROCROLLER_DECLSPEC ToStringVisitor
         {
             std::string call(Operation const&, const unsigned char*);
 
@@ -165,7 +167,7 @@ namespace rocRoller
             const unsigned char* m_runtimeArgs;
         };
 
-        struct SetCommand
+        struct ROCROLLER_DECLSPEC SetCommand
         {
             SetCommand(CommandPtr);
 
@@ -188,7 +190,7 @@ namespace rocRoller
             CommandPtr command;
         };
 
-        struct AllocateArguments
+        struct ROCROLLER_DECLSPEC AllocateArguments
         {
             void call(Operation&);
 
@@ -207,7 +209,7 @@ namespace rocRoller
             void operator()(RandomNumberGenerator&);
         };
 
-        struct VariableTypeVisitor
+        struct ROCROLLER_DECLSPEC VariableTypeVisitor
         {
             rocRoller::VariableType call(Operation&);
 

--- a/lib/include/rocRoller/Operations/Operations_fwd.hpp
+++ b/lib/include/rocRoller/Operations/Operations_fwd.hpp
@@ -29,6 +29,8 @@
  */
 
 #pragma once
+
+#include <rocRoller/rocRoller.hpp>
 #include <string>
 #include <variant>
 
@@ -36,19 +38,19 @@ namespace rocRoller
 {
     namespace Operations
     {
-        struct Tensor;
-        struct Scalar;
-        struct Literal;
-        struct BlockScale;
-        struct T_Load_Linear;
-        struct T_Load_Scalar;
-        struct T_Load_Tiled;
-        struct T_Mul;
-        struct T_Store_Linear;
-        struct T_Store_Tiled;
-        struct T_Execute;
-        struct Nop;
-        struct RandomNumberGenerator;
+        struct ROCROLLER_DECLSPEC Tensor;
+        struct ROCROLLER_DECLSPEC Scalar;
+        struct ROCROLLER_DECLSPEC Literal;
+        struct ROCROLLER_DECLSPEC BlockScale;
+        struct ROCROLLER_DECLSPEC T_Load_Linear;
+        struct ROCROLLER_DECLSPEC T_Load_Scalar;
+        struct ROCROLLER_DECLSPEC T_Load_Tiled;
+        struct ROCROLLER_DECLSPEC T_Mul;
+        struct ROCROLLER_DECLSPEC T_Store_Linear;
+        struct ROCROLLER_DECLSPEC T_Store_Tiled;
+        struct ROCROLLER_DECLSPEC T_Execute;
+        struct ROCROLLER_DECLSPEC Nop;
+        struct ROCROLLER_DECLSPEC RandomNumberGenerator;
         using Operation = std::variant<Tensor,
                                        Scalar,
                                        Literal,
@@ -69,9 +71,9 @@ namespace rocRoller
         template <typename T>
         concept CConcreteOperation = (COperation<T> && !std::same_as<Operation, T>);
 
-        struct Inputs;
-        struct Outputs;
-        struct TagVisitor;
+        struct ROCROLLER_DECLSPEC Inputs;
+        struct ROCROLLER_DECLSPEC Outputs;
+        struct ROCROLLER_DECLSPEC TagVisitor;
 
         std::string name(Operation const&);
 

--- a/lib/include/rocRoller/Operations/RandomNumberGenerator.hpp
+++ b/lib/include/rocRoller/Operations/RandomNumberGenerator.hpp
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include "Operation.hpp"
 
 #include <memory>
@@ -39,7 +41,7 @@ namespace rocRoller
 {
     namespace Operations
     {
-        class RandomNumberGenerator : public BaseOperation
+        class ROCROLLER_DECLSPEC RandomNumberGenerator : public BaseOperation
         {
         public:
             enum class SeedMode
@@ -63,7 +65,8 @@ namespace rocRoller
             bool operator==(RandomNumberGenerator const&) const;
         };
 
-        std::string   toString(RandomNumberGenerator::SeedMode const&);
-        std::ostream& operator<<(std::ostream& stream, RandomNumberGenerator::SeedMode mode);
+        ROCROLLER_DECLSPEC std::string toString(RandomNumberGenerator::SeedMode const&);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&                   stream,
+                                                    RandomNumberGenerator::SeedMode mode);
     }
 }

--- a/lib/include/rocRoller/Operations/T_Execute.hpp
+++ b/lib/include/rocRoller/Operations/T_Execute.hpp
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 #include <unordered_set>
 #include <variant>
@@ -44,7 +46,7 @@ namespace rocRoller
     namespace Operations
     {
 
-        struct E_Unary
+        struct ROCROLLER_DECLSPEC E_Unary
         {
             E_Unary(OperationTag a);
             E_Unary(const std::initializer_list<OperationTag>&);
@@ -65,7 +67,7 @@ namespace rocRoller
 
 // Macro for declaring a new Unary XOp
 #define MAKE_UNARY_XOP(FUNC)                                  \
-    struct FUNC : public E_Unary                              \
+    struct ROCROLLER_DECLSPEC FUNC : public E_Unary           \
     {                                                         \
         FUNC(OperationTag a)                                  \
             : E_Unary(a)                                      \
@@ -86,7 +88,7 @@ namespace rocRoller
         MAKE_UNARY_XOP(E_Not)
         MAKE_UNARY_XOP(E_RandomNumber)
 
-        struct E_Cvt : public E_Unary
+        struct ROCROLLER_DECLSPEC E_Cvt : public E_Unary
         {
             E_Cvt(OperationTag a, rocRoller::DataType destType)
                 : E_Unary(a)
@@ -106,7 +108,7 @@ namespace rocRoller
             rocRoller::DataType destType;
         };
 
-        struct E_Binary
+        struct ROCROLLER_DECLSPEC E_Binary
         {
             E_Binary(OperationTag a, OperationTag b);
             E_Binary(const std::initializer_list<OperationTag>&);
@@ -129,7 +131,7 @@ namespace rocRoller
 
 // Macro for defining a new binary XOp
 #define MAKE_BINARY_XOP(FUNC)                                 \
-    struct FUNC : public E_Binary                             \
+    struct ROCROLLER_DECLSPEC FUNC : public E_Binary          \
     {                                                         \
         FUNC(OperationTag a, OperationTag b)                  \
             : E_Binary(a, b)                                  \
@@ -145,7 +147,7 @@ namespace rocRoller
         }                                                     \
     };
 
-        struct E_StochasticRoundingCvt : public E_Binary
+        struct ROCROLLER_DECLSPEC E_StochasticRoundingCvt : public E_Binary
         {
             E_StochasticRoundingCvt(OperationTag        data,
                                     OperationTag        seed,
@@ -176,7 +178,7 @@ namespace rocRoller
         MAKE_BINARY_XOP(E_Or)
         MAKE_BINARY_XOP(E_GreaterThan)
 
-        struct E_Ternary
+        struct ROCROLLER_DECLSPEC E_Ternary
         {
             E_Ternary(OperationTag a, OperationTag b, OperationTag c);
             E_Ternary(const std::initializer_list<OperationTag>&);
@@ -200,7 +202,7 @@ namespace rocRoller
 
 // Macro for defining a new ternary XOp
 #define MAKE_TERNARY_XOP(FUNC)                                \
-    struct FUNC : public E_Ternary                            \
+    struct ROCROLLER_DECLSPEC FUNC : public E_Ternary         \
     {                                                         \
         FUNC(OperationTag a, OperationTag b, OperationTag c)  \
             : E_Ternary(a, b, c)                              \
@@ -217,7 +219,7 @@ namespace rocRoller
     };
         MAKE_TERNARY_XOP(E_Conditional)
 
-        class T_Execute : public BaseOperation
+        class ROCROLLER_DECLSPEC T_Execute : public BaseOperation
         {
         public:
             T_Execute() = delete;

--- a/lib/include/rocRoller/Operations/T_Execute_fwd.hpp
+++ b/lib/include/rocRoller/Operations/T_Execute_fwd.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 #include <variant>
 
@@ -33,24 +35,24 @@ namespace rocRoller
 {
     namespace Operations
     {
-        struct T_Execute;
-        struct E_Unary;
-        struct E_Binary;
-        struct E_Ternary;
-        struct E_Neg;
-        struct E_Abs;
-        struct E_RandomNumber;
-        struct E_Not;
-        struct E_Cvt;
-        struct E_StochasticRoundingCvt;
-        struct E_Add;
-        struct E_Sub;
-        struct E_Mul;
-        struct E_Div;
-        struct E_And;
-        struct E_Or;
-        struct E_GreaterThan;
-        struct E_Conditional;
+        struct ROCROLLER_DECLSPEC T_Execute;
+        struct ROCROLLER_DECLSPEC E_Unary;
+        struct ROCROLLER_DECLSPEC E_Binary;
+        struct ROCROLLER_DECLSPEC E_Ternary;
+        struct ROCROLLER_DECLSPEC E_Neg;
+        struct ROCROLLER_DECLSPEC E_Abs;
+        struct ROCROLLER_DECLSPEC E_RandomNumber;
+        struct ROCROLLER_DECLSPEC E_Not;
+        struct ROCROLLER_DECLSPEC E_Cvt;
+        struct ROCROLLER_DECLSPEC E_StochasticRoundingCvt;
+        struct ROCROLLER_DECLSPEC E_Add;
+        struct ROCROLLER_DECLSPEC E_Sub;
+        struct ROCROLLER_DECLSPEC E_Mul;
+        struct ROCROLLER_DECLSPEC E_Div;
+        struct ROCROLLER_DECLSPEC E_And;
+        struct ROCROLLER_DECLSPEC E_Or;
+        struct ROCROLLER_DECLSPEC E_GreaterThan;
+        struct ROCROLLER_DECLSPEC E_Conditional;
 
         using XOp = std::variant<E_Neg,
                                  E_Abs,

--- a/lib/include/rocRoller/Operations/T_LoadStore.hpp
+++ b/lib/include/rocRoller/Operations/T_LoadStore.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Operations/Operation.hpp>
 
 #include <rocRoller/Serialization/Base_fwd.hpp>
@@ -34,7 +36,7 @@ namespace rocRoller
 {
     namespace Operations
     {
-        class T_Load_Linear : public BaseOperation
+        class ROCROLLER_DECLSPEC T_Load_Linear : public BaseOperation
         {
         public:
             T_Load_Linear() = delete;
@@ -53,9 +55,9 @@ namespace rocRoller
             OperationTag m_srcTag;
         };
 
-        std::ostream& operator<<(std::ostream& stream, T_Load_Linear const& val);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, T_Load_Linear const& val);
 
-        class T_Load_Scalar : public BaseOperation
+        class ROCROLLER_DECLSPEC T_Load_Scalar : public BaseOperation
         {
         public:
             T_Load_Scalar() = delete;
@@ -74,9 +76,9 @@ namespace rocRoller
             OperationTag m_srcTag;
         };
 
-        std::ostream& operator<<(std::ostream& stream, T_Load_Scalar const& val);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, T_Load_Scalar const& val);
 
-        class T_Load_Tiled : public BaseOperation
+        class ROCROLLER_DECLSPEC T_Load_Tiled : public BaseOperation
         {
         public:
             T_Load_Tiled() = delete;
@@ -95,9 +97,9 @@ namespace rocRoller
             OperationTag m_srcTag;
         };
 
-        std::ostream& operator<<(std::ostream& stream, T_Load_Tiled const& val);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, T_Load_Tiled const& val);
 
-        class T_Store_Linear : public BaseOperation
+        class ROCROLLER_DECLSPEC T_Store_Linear : public BaseOperation
         {
             template <typename T1, typename T2, typename T3>
             friend struct rocRoller::Serialization::MappingTraits;
@@ -117,9 +119,10 @@ namespace rocRoller
             OperationTag m_dstTag;
         };
 
-        std::ostream& operator<<(std::ostream& stream, T_Store_Linear const& val);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&         stream,
+                                                    T_Store_Linear const& val);
 
-        class T_Store_Tiled : public BaseOperation
+        class ROCROLLER_DECLSPEC T_Store_Tiled : public BaseOperation
         {
         public:
             T_Store_Tiled() = delete;
@@ -139,6 +142,6 @@ namespace rocRoller
             OperationTag m_dstTag;
         };
 
-        std::ostream& operator<<(std::ostream& stream, T_Store_Tiled const& val);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, T_Store_Tiled const& val);
     }
 }

--- a/lib/include/rocRoller/Operations/T_Mul.hpp
+++ b/lib/include/rocRoller/Operations/T_Mul.hpp
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <unordered_set>
 
 #include <rocRoller/DataTypes/DataTypes.hpp>
@@ -40,7 +42,7 @@ namespace rocRoller
 {
     namespace Operations
     {
-        class T_Mul : public BaseOperation
+        class ROCROLLER_DECLSPEC T_Mul : public BaseOperation
         {
         public:
             T_Mul() = delete;

--- a/lib/include/rocRoller/Operations/TensorScalar.hpp
+++ b/lib/include/rocRoller/Operations/TensorScalar.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/DataTypes/DataTypes.hpp>
 #include <rocRoller/Operations/CommandArgument.hpp>
 #include <rocRoller/Operations/CommandArguments_fwd.hpp>
@@ -36,7 +38,7 @@ namespace rocRoller
 {
     namespace Operations
     {
-        class Literal : public BaseOperation
+        class ROCROLLER_DECLSPEC Literal : public BaseOperation
         {
         public:
             Literal() = delete;
@@ -54,9 +56,9 @@ namespace rocRoller
             CommandArgumentValue m_value;
         };
 
-        std::ostream& operator<<(std::ostream& stream, Literal const& val);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, Literal const& val);
 
-        class Scalar : public BaseOperation
+        class ROCROLLER_DECLSPEC Scalar : public BaseOperation
         {
         public:
             Scalar() = delete;
@@ -82,9 +84,9 @@ namespace rocRoller
             VariableType       m_variableType;
         };
 
-        std::ostream& operator<<(std::ostream& stream, Scalar const& val);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, Scalar const& val);
 
-        class Tensor : public BaseOperation
+        class ROCROLLER_DECLSPEC Tensor : public BaseOperation
         {
         public:
             Tensor() = delete;
@@ -129,7 +131,7 @@ namespace rocRoller
             std::vector<size_t> m_literalStrides;
         };
 
-        std::ostream& operator<<(std::ostream& stream, Tensor const& val);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, Tensor const& val);
     }
 }
 

--- a/lib/include/rocRoller/Operations/TensorScalar_fwd.hpp
+++ b/lib/include/rocRoller/Operations/TensorScalar_fwd.hpp
@@ -26,11 +26,13 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Operations
     {
-        class Scalar;
-        class Tensor;
+        class ROCROLLER_DECLSPEC Scalar;
+        class ROCROLLER_DECLSPEC Tensor;
     }
 }

--- a/lib/include/rocRoller/ScheduledInstructions.hpp
+++ b/lib/include/rocRoller/ScheduledInstructions.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <sstream>
 #include <vector>
 
@@ -35,7 +37,7 @@
 
 namespace rocRoller
 {
-    class ScheduledInstructions
+    class ROCROLLER_DECLSPEC ScheduledInstructions
     {
     public:
         explicit ScheduledInstructions(ContextPtr ctx);

--- a/lib/include/rocRoller/ScheduledInstructions_fwd.hpp
+++ b/lib/include/rocRoller/ScheduledInstructions_fwd.hpp
@@ -26,7 +26,9 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
-    class ScheduledInstructions;
+    class ROCROLLER_DECLSPEC ScheduledInstructions;
 }

--- a/lib/include/rocRoller/Scheduling/CooperativeScheduler.hpp
+++ b/lib/include/rocRoller/Scheduling/CooperativeScheduler.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -45,7 +47,7 @@ namespace rocRoller
          * the minimum cost, and yielding from that stream until an
          * instruction with a non-zero cost is encountered.
          */
-        class CooperativeScheduler : public Scheduler
+        class ROCROLLER_DECLSPEC CooperativeScheduler : public Scheduler
         {
         public:
             CooperativeScheduler(ContextPtr, CostFunction);

--- a/lib/include/rocRoller/Scheduling/CooperativeScheduler_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/CooperativeScheduler_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Scheduling
     {
-        class CooperativeScheduler;
+        class ROCROLLER_DECLSPEC CooperativeScheduler;
     }
 }

--- a/lib/include/rocRoller/Scheduling/Costs/Cost.hpp
+++ b/lib/include/rocRoller/Scheduling/Costs/Cost.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -45,7 +47,7 @@ namespace rocRoller
          *
          * - This class should be able to be made into `ComponentBase` class
          */
-        class Cost
+        class ROCROLLER_DECLSPEC Cost
         {
         public:
             using Argument = std::tuple<CostFunction, rocRoller::ContextPtr>;
@@ -84,7 +86,7 @@ namespace rocRoller
             std::weak_ptr<rocRoller::Context> m_ctx;
         };
 
-        std::ostream& operator<<(std::ostream&, CostFunction);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, CostFunction);
     }
 }
 

--- a/lib/include/rocRoller/Scheduling/Costs/Cost_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/Costs/Cost_fwd.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 namespace rocRoller
 {
@@ -41,8 +43,8 @@ namespace rocRoller
             Count
         };
 
-        class Cost;
+        class ROCROLLER_DECLSPEC Cost;
 
-        std::string toString(CostFunction);
+        ROCROLLER_DECLSPEC std::string toString(CostFunction);
     }
 }

--- a/lib/include/rocRoller/Scheduling/Costs/LinearWeightedCost.hpp
+++ b/lib/include/rocRoller/Scheduling/Costs/LinearWeightedCost.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -44,7 +46,7 @@ namespace rocRoller
          * multiplied by each coefficient to arrive at the cost of a particular
          * function.
          */
-        struct Weights
+        struct ROCROLLER_DECLSPEC Weights
         {
             /// Does the instruction require a nop before it?
             /// One per nop.
@@ -135,7 +137,7 @@ namespace rocRoller
         /**
          * LinearWeightedCost: Orders the instructions based on a linear combination of a number of factors.
          */
-        class LinearWeightedCost : public Cost
+        class ROCROLLER_DECLSPEC LinearWeightedCost : public Cost
         {
         public:
             LinearWeightedCost(ContextPtr);

--- a/lib/include/rocRoller/Scheduling/Costs/LinearWeightedCost_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/Costs/LinearWeightedCost_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Scheduling
     {
-        class LinearWeightedCost;
+        class ROCROLLER_DECLSPEC LinearWeightedCost;
     }
 }

--- a/lib/include/rocRoller/Scheduling/Costs/MinNopsCost.hpp
+++ b/lib/include/rocRoller/Scheduling/Costs/MinNopsCost.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -41,7 +43,7 @@ namespace rocRoller
         /**
          * MinNopsCost: Orders the instructions based on the number of Nops.
          */
-        class MinNopsCost : public Cost
+        class ROCROLLER_DECLSPEC MinNopsCost : public Cost
         {
         public:
             MinNopsCost(ContextPtr);

--- a/lib/include/rocRoller/Scheduling/Costs/MinNopsCost_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/Costs/MinNopsCost_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Scheduling
     {
-        class MinNopsCost;
+        class ROCROLLER_DECLSPEC MinNopsCost;
     }
 }

--- a/lib/include/rocRoller/Scheduling/Costs/NoneCost.hpp
+++ b/lib/include/rocRoller/Scheduling/Costs/NoneCost.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -41,7 +43,7 @@ namespace rocRoller
         /**
          * NoneCost: This cost can be used for cost-independent schedulers. If it's ever initialized an exception is thrown.
          */
-        class NoneCost : public Cost
+        class ROCROLLER_DECLSPEC NoneCost : public Cost
         {
         public:
             NoneCost(ContextPtr);

--- a/lib/include/rocRoller/Scheduling/Costs/NoneCost_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/Costs/NoneCost_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Scheduling
     {
-        class NoneCost;
+        class ROCROLLER_DECLSPEC NoneCost;
     }
 }

--- a/lib/include/rocRoller/Scheduling/Costs/UniformCost.hpp
+++ b/lib/include/rocRoller/Scheduling/Costs/UniformCost.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -41,7 +43,7 @@ namespace rocRoller
         /**
          * UniformCost: Gives zero cost to all instructions.
          */
-        class UniformCost : public Cost
+        class ROCROLLER_DECLSPEC UniformCost : public Cost
         {
         public:
             UniformCost(ContextPtr);

--- a/lib/include/rocRoller/Scheduling/Costs/UniformCost_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/Costs/UniformCost_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Scheduling
     {
-        class UniformCost;
+        class ROCROLLER_DECLSPEC UniformCost;
     }
 }

--- a/lib/include/rocRoller/Scheduling/Costs/WaitCntNopCost.hpp
+++ b/lib/include/rocRoller/Scheduling/Costs/WaitCntNopCost.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -41,7 +43,7 @@ namespace rocRoller
         /**
          * WaitCntNopCost: Orders the instructions based on the number of Nops and WaitCnts.
          */
-        class WaitCntNopCost : public Cost
+        class ROCROLLER_DECLSPEC WaitCntNopCost : public Cost
         {
         public:
             WaitCntNopCost(ContextPtr);

--- a/lib/include/rocRoller/Scheduling/Costs/WaitCntNopCost_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/Costs/WaitCntNopCost_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Scheduling
     {
-        class WaitCntNopCost;
+        class ROCROLLER_DECLSPEC WaitCntNopCost;
     }
 }

--- a/lib/include/rocRoller/Scheduling/MetaObserver.hpp
+++ b/lib/include/rocRoller/Scheduling/MetaObserver.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <tuple>
@@ -42,7 +44,7 @@ namespace rocRoller
     namespace Scheduling
     {
         template <CObserver... Types>
-        class MetaObserver : public IObserver
+        class ROCROLLER_DECLSPEC MetaObserver : public IObserver
         {
         public:
             using Tup = std::tuple<Types...>;

--- a/lib/include/rocRoller/Scheduling/Observers/AllocatingObserver.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/AllocatingObserver.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Context.hpp>
 #include <rocRoller/GPUArchitecture/GPUInstructionInfo.hpp>
 #include <rocRoller/Scheduling/Scheduling.hpp>
@@ -34,7 +36,7 @@ namespace rocRoller
 {
     namespace Scheduling
     {
-        class AllocatingObserver
+        class ROCROLLER_DECLSPEC AllocatingObserver
         {
         public:
             AllocatingObserver() {}

--- a/lib/include/rocRoller/Scheduling/Observers/FileWritingObserver.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/FileWritingObserver.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <filesystem>
 #include <fstream>
 #include <stdlib.h>
@@ -39,7 +41,7 @@ namespace rocRoller
 {
     namespace Scheduling
     {
-        class FileWritingObserver
+        class ROCROLLER_DECLSPEC FileWritingObserver
         {
         public:
             FileWritingObserver() {}

--- a/lib/include/rocRoller/Scheduling/Observers/FunctionalUnit/MFMAObserver.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/FunctionalUnit/MFMAObserver.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -37,7 +39,7 @@ namespace rocRoller
     namespace Scheduling
     {
 
-        class MFMAObserver
+        class ROCROLLER_DECLSPEC MFMAObserver
         {
         public:
             MFMAObserver();

--- a/lib/include/rocRoller/Scheduling/Observers/FunctionalUnit/WMMAObserver.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/FunctionalUnit/WMMAObserver.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -37,7 +39,7 @@ namespace rocRoller
     namespace Scheduling
     {
 
-        class WMMAObserver
+        class ROCROLLER_DECLSPEC WMMAObserver
         {
         public:
             WMMAObserver();

--- a/lib/include/rocRoller/Scheduling/Observers/ObserverCreation.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/ObserverCreation.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -51,7 +53,7 @@ namespace rocRoller
         std::shared_ptr<Scheduling::IObserver> createObserver(ContextPtr const& ctx);
 
         template <CObserver... Types>
-        struct PotentialObservers
+        struct ROCROLLER_DECLSPEC PotentialObservers
         {
         };
 

--- a/lib/include/rocRoller/Scheduling/Observers/RegisterLivenessObserver.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/RegisterLivenessObserver.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <unordered_map>
 
 #include <rocRoller/Context.hpp>
@@ -46,7 +48,7 @@ namespace rocRoller
             Count
         };
 
-        struct LivenessHistoryEntry
+        struct ROCROLLER_DECLSPEC LivenessHistoryEntry
         {
             std::string instruction;
             std::unordered_map<Register::Type, std::unordered_map<size_t, RegisterLiveState>>
@@ -57,7 +59,7 @@ namespace rocRoller
             size_t      lineNumber = 0;
         };
 
-        class RegisterLivenessObserver
+        class ROCROLLER_DECLSPEC RegisterLivenessObserver
         {
         public:
             RegisterLivenessObserver() {}
@@ -150,8 +152,9 @@ namespace rocRoller
             std::string livenessString() const;
         };
 
-        std::string   toString(RegisterLiveState const& rls);
-        std::ostream& operator<<(std::ostream& stream, RegisterLiveState const& rls);
+        ROCROLLER_DECLSPEC std::string toString(RegisterLiveState const& rls);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&            stream,
+                                                    RegisterLiveState const& rls);
 
         static_assert(CObserverRuntime<RegisterLivenessObserver>);
     }

--- a/lib/include/rocRoller/Scheduling/Observers/SupportedInstructionObserver.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/SupportedInstructionObserver.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/Instruction.hpp>
 #include <rocRoller/Scheduling/Scheduling.hpp>
 #include <rocRoller/Utilities/Settings.hpp>
@@ -42,7 +44,7 @@ namespace rocRoller
          * present in the GPUArchitecture, then an exception is thrown.
          *
          */
-        class SupportedInstructionObserver
+        class ROCROLLER_DECLSPEC SupportedInstructionObserver
         {
         public:
             SupportedInstructionObserver() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/BufferStoreDwordXXRead.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/BufferStoreDwordXXRead.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -49,7 +51,8 @@ namespace rocRoller
          * NOTE: If soffset argument is an SGPR, no NOPs required
          *
          */
-        class BufferStoreDwordXXRead : public WaitStateObserver<BufferStoreDwordXXRead>
+        class ROCROLLER_DECLSPEC BufferStoreDwordXXRead
+            : public WaitStateObserver<BufferStoreDwordXXRead>
         {
         public:
             BufferStoreDwordXXRead() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/ACCVGPRReadWrite.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/ACCVGPRReadWrite.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -42,7 +44,7 @@ namespace rocRoller
          * | 908  | v_accvgpr_read write | v_accvgpr_write read SrcA | 2    |
          *
          */
-        class ACCVGPRReadWrite : public WaitStateObserver<ACCVGPRReadWrite>
+        class ROCROLLER_DECLSPEC ACCVGPRReadWrite : public WaitStateObserver<ACCVGPRReadWrite>
         {
         public:
             ACCVGPRReadWrite() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/ACCVGPRWriteWrite.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/ACCVGPRWriteWrite.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -42,7 +44,7 @@ namespace rocRoller
          * | 908  | v_accvgpr_write write | v_accvgpr_read read SrcA  | 3    |
          *
          */
-        class ACCVGPRWriteWrite : public WaitStateObserver<ACCVGPRWriteWrite>
+        class ROCROLLER_DECLSPEC ACCVGPRWriteWrite : public WaitStateObserver<ACCVGPRWriteWrite>
         {
         public:
             ACCVGPRWriteWrite() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/CMPXWriteExec.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/CMPXWriteExec.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -43,7 +45,7 @@ namespace rocRoller
          * | 94x  | v_cmpx* write EXEC | v_mfma*         | 4    |
          *
          */
-        class CMPXWriteExec : public WaitStateObserver<CMPXWriteExec>
+        class ROCROLLER_DECLSPEC CMPXWriteExec : public WaitStateObserver<CMPXWriteExec>
         {
         public:
             CMPXWriteExec() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/DGEMM16x16x4Write.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/DGEMM16x16x4Write.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -59,7 +61,7 @@ namespace rocRoller
          * Note: v_mfma_f64_16x16x4_f64 is an equivalent variant for 94x
          *
          */
-        class DGEMM16x16x4Write : public WaitStateObserver<DGEMM16x16x4Write>
+        class ROCROLLER_DECLSPEC DGEMM16x16x4Write : public WaitStateObserver<DGEMM16x16x4Write>
         {
         public:
             DGEMM16x16x4Write() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/DGEMM4x4x4Write.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/DGEMM4x4x4Write.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -55,7 +57,7 @@ namespace rocRoller
          * | 94x  | v_mfma_f64_4x4x4f64 write | flat* read overlapped              | 9    |
          *
          */
-        class DGEMM4x4x4Write : public WaitStateObserver<DGEMM4x4x4Write>
+        class ROCROLLER_DECLSPEC DGEMM4x4x4Write : public WaitStateObserver<DGEMM4x4x4Write>
         {
         public:
             DGEMM4x4x4Write() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/DLWrite.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/DLWrite.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -45,7 +47,7 @@ namespace rocRoller
          * | 94x  | v_dot* write | Different opcode            | 3    |
          *
          */
-        class DLWrite : public WaitStateObserver<DLWrite>
+        class ROCROLLER_DECLSPEC DLWrite : public WaitStateObserver<DLWrite>
         {
         public:
             DLWrite() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/VALUWrite.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/VALUWrite.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -43,7 +45,7 @@ namespace rocRoller
          * | 94x  | v_* write | v_mfma* read         | 2    |
          *
          */
-        class VALUWrite : public WaitStateObserver<VALUWrite>
+        class ROCROLLER_DECLSPEC VALUWrite : public WaitStateObserver<VALUWrite>
         {
         public:
             VALUWrite() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLReadSrcC908.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLReadSrcC908.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -42,7 +44,7 @@ namespace rocRoller
          * | 908  | v_mfma* read SrcC (16 pass) | v_accvgpr_write write overlapped | 13   |
          *
          */
-        class XDLReadSrcC908 : public WaitStateObserver<XDLReadSrcC908>
+        class ROCROLLER_DECLSPEC XDLReadSrcC908 : public WaitStateObserver<XDLReadSrcC908>
         {
         public:
             XDLReadSrcC908() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLReadSrcC90a.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLReadSrcC90a.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -42,7 +44,7 @@ namespace rocRoller
          * | 90a  | v_mfma* read SrcC (16 pass) | v_* write | 19   |
          *
          */
-        class XDLReadSrcC90a : public WaitStateObserver<XDLReadSrcC90a>
+        class ROCROLLER_DECLSPEC XDLReadSrcC90a : public WaitStateObserver<XDLReadSrcC90a>
         {
         public:
             XDLReadSrcC90a() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLReadSrcC94x.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLReadSrcC94x.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -43,7 +45,7 @@ namespace rocRoller
          * | 94x  | v_mfma* read SrcC (16 pass) | v_* write | 15   |
          *
          */
-        class XDLReadSrcC94x : public WaitStateObserver<XDLReadSrcC94x>
+        class ROCROLLER_DECLSPEC XDLReadSrcC94x : public WaitStateObserver<XDLReadSrcC94x>
         {
         public:
             XDLReadSrcC94x() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLWrite908.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLWrite908.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -48,7 +50,7 @@ namespace rocRoller
          * | 908  | v_mfma* write (16 pass) | v_accvgpr_write write        | 15   |
          *
          */
-        class XDLWrite908 : public WaitStateObserver<XDLWrite908>
+        class ROCROLLER_DECLSPEC XDLWrite908 : public WaitStateObserver<XDLWrite908>
         {
         public:
             XDLWrite908() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLWrite90a.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLWrite90a.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -63,7 +65,7 @@ namespace rocRoller
          * | 90a  | v_mfma* write (16 pass) | v_* read/write                     | 19   |
          *
          */
-        class XDLWrite90a : public WaitStateObserver<XDLWrite90a>
+        class ROCROLLER_DECLSPEC XDLWrite90a : public WaitStateObserver<XDLWrite90a>
         {
         public:
             XDLWrite90a() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLWrite94x.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLWrite94x.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -101,7 +103,7 @@ namespace rocRoller
          * | 94x  | v_mfma* write (16 pass)     | v_* read/write                     | 19   |
          *
          */
-        class XDLWrite94x : public WaitStateObserver<XDLWrite94x>
+        class ROCROLLER_DECLSPEC XDLWrite94x : public WaitStateObserver<XDLWrite94x>
         {
         public:
             XDLWrite94x() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/OPSEL94x.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/OPSEL94x.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -41,7 +43,7 @@ namespace rocRoller
          * | 94x  | v_* using SDWA  | v_* read | 1    |
          *
          */
-        class OPSEL94x : public WaitStateObserver<OPSEL94x>
+        class ROCROLLER_DECLSPEC OPSEL94x : public WaitStateObserver<OPSEL94x>
         {
         public:
             OPSEL94x() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUTransWrite94x.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUTransWrite94x.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -59,7 +61,7 @@ namespace rocRoller
          * | 94x  | v_log_legacy_f32     | v_*                      | 1    |
          *
          */
-        class VALUTransWrite94x : public WaitStateObserver<VALUTransWrite94x>
+        class ROCROLLER_DECLSPEC VALUTransWrite94x : public WaitStateObserver<VALUTransWrite94x>
         {
         public:
             VALUTransWrite94x() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUWriteReadlane94x.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUWriteReadlane94x.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -41,7 +43,8 @@ namespace rocRoller
          * | 950  | v_* write | v_permlane* read     | 2    |
          *
          */
-        class VALUWriteReadlane94x : public WaitStateObserver<VALUWriteReadlane94x>
+        class ROCROLLER_DECLSPEC VALUWriteReadlane94x
+            : public WaitStateObserver<VALUWriteReadlane94x>
         {
         public:
             VALUWriteReadlane94x() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUWriteSGPRVCC94x.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUWriteSGPRVCC94x.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -57,7 +59,7 @@ namespace rocRoller
          * NOTE: If the SGPR/VCC is read as a carry in these cases, 0 NOPs are required.
          *
          */
-        class VALUWriteSGPRVCC94x : public WaitStateObserver<VALUWriteSGPRVCC94x>
+        class ROCROLLER_DECLSPEC VALUWriteSGPRVCC94x : public WaitStateObserver<VALUWriteSGPRVCC94x>
         {
         public:
             VALUWriteSGPRVCC94x() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUWriteSGPRVMEM.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUWriteSGPRVMEM.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -42,7 +44,7 @@ namespace rocRoller
          * | 94x  | v_* write SGPR | VMEM read SGPR | 5    |
          *
          */
-        class VALUWriteSGPRVMEM : public WaitStateObserver<VALUWriteSGPRVMEM>
+        class ROCROLLER_DECLSPEC VALUWriteSGPRVMEM : public WaitStateObserver<VALUWriteSGPRVMEM>
         {
         public:
             VALUWriteSGPRVMEM() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUWriteVCCVDIVFMAS.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUWriteVCCVDIVFMAS.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -42,7 +44,8 @@ namespace rocRoller
          * | 94x  | v_* write VCC | v_div_fmas | 4    |
          *
          */
-        class VALUWriteVCCVDIVFMAS : public WaitStateObserver<VALUWriteVCCVDIVFMAS>
+        class ROCROLLER_DECLSPEC VALUWriteVCCVDIVFMAS
+            : public WaitStateObserver<VALUWriteVCCVDIVFMAS>
         {
         public:
             VALUWriteVCCVDIVFMAS() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/VCMPXWrite94x.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/VCMPXWrite94x.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -45,7 +47,7 @@ namespace rocRoller
          * | 950  | v_cmpx_*  | v_permlane*       | 4    |
          *
          */
-        class VCMPXWrite94x : public WaitStateObserver<VCMPXWrite94x>
+        class ROCROLLER_DECLSPEC VCMPXWrite94x : public WaitStateObserver<VCMPXWrite94x>
         {
         public:
             VCMPXWrite94x() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/WMMA/WMMAReadSrcD.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/WMMA/WMMAReadSrcD.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -41,7 +43,7 @@ namespace rocRoller
          * | 120x  | v_wmma* read SrcC (16 pass) | v_* read | 8    |
          *
          */
-        class WMMAReadSrcD : public WaitStateObserver<WMMAReadSrcD>
+        class ROCROLLER_DECLSPEC WMMAReadSrcD : public WaitStateObserver<WMMAReadSrcD>
         {
         public:
             WMMAReadSrcD() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/WMMA/WMMAWrite.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/WMMA/WMMAWrite.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -40,7 +42,7 @@ namespace rocRoller
          * | 120x  | v_wmma*  | v_wmma* read SrcA/B | 1    |
          *
          */
-        class WMMAWrite : public WaitStateObserver<WMMAWrite>
+        class ROCROLLER_DECLSPEC WMMAWrite : public WaitStateObserver<WMMAWrite>
         {
         public:
             WMMAWrite() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/WMMA/WMMAWriteSrcD.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/WMMA/WMMAWriteSrcD.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
 
 namespace rocRoller
@@ -41,7 +43,7 @@ namespace rocRoller
          * | 120x  | v_wmma* read SrcC (16 pass) | v_* write | 8    |
          *
          */
-        class WMMAWriteSrcD : public WaitStateObserver<WMMAWriteSrcD>
+        class ROCROLLER_DECLSPEC WMMAWriteSrcD : public WaitStateObserver<WMMAWriteSrcD>
         {
         public:
             WMMAWriteSrcD() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <optional>
 
@@ -104,7 +106,7 @@ namespace rocRoller
         };
 
         template <class DerivedObserver>
-        class WaitStateObserver
+        class ROCROLLER_DECLSPEC WaitStateObserver
         {
         public:
             WaitStateObserver() {}

--- a/lib/include/rocRoller/Scheduling/Observers/WaitcntObserver.hpp
+++ b/lib/include/rocRoller/Scheduling/Observers/WaitcntObserver.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Context.hpp>
 #include <rocRoller/GPUArchitecture/GPUInstructionInfo.hpp>
 #include <rocRoller/Scheduling/Scheduling.hpp>
@@ -43,7 +45,7 @@ namespace rocRoller
          * @brief This struct is used to store the _unallocated_ state of the waitcnt queues.
          *
          */
-        struct WaitcntState
+        struct ROCROLLER_DECLSPEC WaitcntState
         {
         public:
             WaitcntState();
@@ -74,7 +76,7 @@ namespace rocRoller
             WaitQueueMap<GPUWaitQueueType> m_typeInQueue;
         };
 
-        class WaitcntObserver
+        class ROCROLLER_DECLSPEC WaitcntObserver
         {
         public:
             WaitcntObserver();

--- a/lib/include/rocRoller/Scheduling/PriorityScheduler.hpp
+++ b/lib/include/rocRoller/Scheduling/PriorityScheduler.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -45,7 +47,7 @@ namespace rocRoller
          * instruction from the the lowest index stream with the
          * least cost.
          */
-        class PriorityScheduler : public Scheduler
+        class ROCROLLER_DECLSPEC PriorityScheduler : public Scheduler
         {
         public:
             PriorityScheduler(ContextPtr, CostFunction);

--- a/lib/include/rocRoller/Scheduling/PriorityScheduler_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/PriorityScheduler_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Scheduling
     {
-        class PriorityScheduler;
+        class ROCROLLER_DECLSPEC PriorityScheduler;
     }
 }

--- a/lib/include/rocRoller/Scheduling/RandomScheduler.hpp
+++ b/lib/include/rocRoller/Scheduling/RandomScheduler.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -45,7 +47,7 @@ namespace rocRoller
          * The same random seed should produce the same program, regardless of addition or
          * removal of comment-only instructions. Respects the locking rules.
          */
-        class RandomScheduler : public Scheduler
+        class ROCROLLER_DECLSPEC RandomScheduler : public Scheduler
         {
         public:
             RandomScheduler(ContextPtr);

--- a/lib/include/rocRoller/Scheduling/RandomScheduler_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/RandomScheduler_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Scheduling
     {
-        class RandomScheduler;
+        class ROCROLLER_DECLSPEC RandomScheduler;
     }
 }

--- a/lib/include/rocRoller/Scheduling/RoundRobinScheduler.hpp
+++ b/lib/include/rocRoller/Scheduling/RoundRobinScheduler.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -44,7 +46,7 @@ namespace rocRoller
          *
          * Must also follow the locking rules.
          */
-        class RoundRobinScheduler : public Scheduler
+        class ROCROLLER_DECLSPEC RoundRobinScheduler : public Scheduler
         {
         public:
             RoundRobinScheduler(ContextPtr);

--- a/lib/include/rocRoller/Scheduling/RoundRobinScheduler_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/RoundRobinScheduler_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Scheduling
     {
-        class RoundRobinScheduler;
+        class ROCROLLER_DECLSPEC RoundRobinScheduler;
     }
 }

--- a/lib/include/rocRoller/Scheduling/Scheduler.hpp
+++ b/lib/include/rocRoller/Scheduling/Scheduler.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 #include <vector>
 
@@ -40,7 +42,7 @@ namespace rocRoller
 {
     namespace Scheduling
     {
-        class LockState
+        class ROCROLLER_DECLSPEC LockState
         {
         public:
             explicit LockState(ContextPtr ctx);
@@ -79,7 +81,7 @@ namespace rocRoller
          *
          * - This class should be able to be made into `ComponentBase` class
          */
-        class Scheduler
+        class ROCROLLER_DECLSPEC Scheduler
         {
         public:
             using Argument = std::tuple<SchedulerProcedure, CostFunction, rocRoller::ContextPtr>;
@@ -132,8 +134,8 @@ namespace rocRoller
                                std::vector<Generator<Instruction>::iterator>& iterators);
         };
 
-        std::ostream& operator<<(std::ostream&, SchedulerProcedure const&);
-        std::ostream& operator<<(std::ostream&, Dependency const&);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, SchedulerProcedure const&);
+        ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, Dependency const&);
     }
 }
 

--- a/lib/include/rocRoller/Scheduling/Scheduler_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/Scheduler_fwd.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 namespace rocRoller
 {
@@ -52,10 +54,10 @@ namespace rocRoller
             Count
         };
 
-        class Scheduler;
-        class LockState;
+        class ROCROLLER_DECLSPEC Scheduler;
+        class ROCROLLER_DECLSPEC LockState;
 
-        std::string toString(SchedulerProcedure const&);
-        std::string toString(Dependency const&);
+        ROCROLLER_DECLSPEC std::string toString(SchedulerProcedure const&);
+        ROCROLLER_DECLSPEC std::string toString(Dependency const&);
     }
 }

--- a/lib/include/rocRoller/Scheduling/Scheduling.hpp
+++ b/lib/include/rocRoller/Scheduling/Scheduling.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -47,7 +49,7 @@ namespace rocRoller
          * 1. Have a neutral default value, either in the declaration or in the constructor
          * 2. Be added to the combine() function which is used to merge values from different observers.
          */
-        struct InstructionStatus
+        struct ROCROLLER_DECLSPEC InstructionStatus
         {
             unsigned int stallCycles = 0;
             WaitCount    waitCount;
@@ -124,7 +126,7 @@ namespace rocRoller
                 } -> std::convertible_to<bool>;
         };
 
-        struct IObserver
+        struct ROCROLLER_DECLSPEC IObserver
         {
             virtual ~IObserver();
 

--- a/lib/include/rocRoller/Scheduling/Scheduling_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/Scheduling_fwd.hpp
@@ -26,12 +26,14 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Scheduling
     {
-        struct InstructionStatus;
-        struct IObserver;
+        struct ROCROLLER_DECLSPEC InstructionStatus;
+        struct ROCROLLER_DECLSPEC IObserver;
     }
 
 }

--- a/lib/include/rocRoller/Scheduling/SequentialScheduler.hpp
+++ b/lib/include/rocRoller/Scheduling/SequentialScheduler.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <string>
 #include <vector>
@@ -48,7 +50,7 @@ namespace rocRoller
          * comments from the beginning of new streams, for the purpose of finding
          * and running Deallocate nodes as soon as they are available.
          */
-        class SequentialScheduler : public Scheduler
+        class ROCROLLER_DECLSPEC SequentialScheduler : public Scheduler
         {
         public:
             SequentialScheduler(ContextPtr);

--- a/lib/include/rocRoller/Scheduling/SequentialScheduler_fwd.hpp
+++ b/lib/include/rocRoller/Scheduling/SequentialScheduler_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Scheduling
     {
-        class SequentialScheduler;
+        class ROCROLLER_DECLSPEC SequentialScheduler;
     }
 }

--- a/lib/include/rocRoller/Scheduling/WaitStateHazardCounter.hpp
+++ b/lib/include/rocRoller/Scheduling/WaitStateHazardCounter.hpp
@@ -26,13 +26,15 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 namespace rocRoller
 {
     namespace Scheduling
     {
-        class WaitStateHazardCounter
+        class ROCROLLER_DECLSPEC WaitStateHazardCounter
         {
         public:
             WaitStateHazardCounter() {}

--- a/lib/include/rocRoller/Serialization/AssemblyKernel.hpp
+++ b/lib/include/rocRoller/Serialization/AssemblyKernel.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #ifdef ROCROLLER_USE_LLVM
 #include <llvm/ObjectYAML/YAML.h>
 #endif
@@ -45,7 +47,7 @@ namespace rocRoller
     namespace Serialization
     {
         template <typename IO>
-        struct MappingTraits<AssemblyKernelArgument, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC MappingTraits<AssemblyKernelArgument, IO, EmptyContext>
         {
             static const bool flow = false;
             using iot              = IOTraits<IO>;
@@ -79,7 +81,7 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct MappingTraits<AssemblyKernel, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC MappingTraits<AssemblyKernel, IO, EmptyContext>
         {
             static const bool flow = false;
             using iot              = IOTraits<IO>;
@@ -179,7 +181,7 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct MappingTraits<AssemblyKernels, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC MappingTraits<AssemblyKernels, IO, EmptyContext>
         {
             static const bool flow = false;
             using iot              = IOTraits<IO>;

--- a/lib/include/rocRoller/Serialization/Base.hpp
+++ b/lib/include/rocRoller/Serialization/Base.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <algorithm>
 #include <concepts>
 #include <cstddef>
@@ -41,7 +43,7 @@ namespace llvm
 {
     namespace yaml
     {
-        struct EmptyContext;
+        struct ROCROLLER_DECLSPEC EmptyContext;
     }
 }
 #endif
@@ -53,19 +55,19 @@ namespace rocRoller
 #ifdef ROCROLLER_USE_LLVM
         using EmptyContext = llvm::yaml::EmptyContext;
 #else
-        struct EmptyContext
+        struct ROCROLLER_DECLSPEC EmptyContext
         {
         };
 #endif
 
         /**
-         * Override this struct for a type to use a custom constructor.
+         * Override this struct ROCROLLER_DECLSPEC for a type to use a custom constructor.
          *
          * Useful for Variant and SharedPointer is the types default
          * contructor has been explicitly deleted.
          */
         template <typename T, typename U>
-        struct DefaultConstruct
+        struct ROCROLLER_DECLSPEC DefaultConstruct
         {
             static T call()
             {
@@ -74,7 +76,7 @@ namespace rocRoller
         };
 
         /**
-         * Override this struct for a type to use a custom string serialization.
+         * Override this struct ROCROLLER_DECLSPEC for a type to use a custom string serialization.
          *
          * You must implement:
          * 1. static std::string output(T)
@@ -89,41 +91,41 @@ namespace rocRoller
          *
          */
         template <typename T>
-        struct ScalarTraits
+        struct ROCROLLER_DECLSPEC ScalarTraits
         {
         };
 
         template <typename IO>
-        struct IOTraits
+        struct ROCROLLER_DECLSPEC IOTraits
         {
         };
 
         template <typename T, typename IO, typename Context = EmptyContext>
-        struct MappingTraits
+        struct ROCROLLER_DECLSPEC MappingTraits
         {
             static const bool flow = false;
         };
 
         template <typename T, typename IO>
-        struct CustomMappingTraits
+        struct ROCROLLER_DECLSPEC CustomMappingTraits
         {
             static const bool flow = false;
         };
 
         template <typename T, typename IO>
-        struct SequenceTraits
+        struct ROCROLLER_DECLSPEC SequenceTraits
         {
             using Value            = int;
             static const bool flow = false;
         };
 
         template <typename T, typename IO>
-        struct EnumTraits
+        struct ROCROLLER_DECLSPEC EnumTraits
         {
         };
 
         template <typename Object, typename IO, typename Context = EmptyContext>
-        struct EmptyMappingTraits
+        struct ROCROLLER_DECLSPEC EmptyMappingTraits
         {
             using iot = IOTraits<IO>;
             // static_assert(Object::HasValue == false,
@@ -135,7 +137,7 @@ namespace rocRoller
         };
 
         template <typename Object, typename IO>
-        struct ValueMappingTraits
+        struct ROCROLLER_DECLSPEC ValueMappingTraits
         {
             using iot = IOTraits<IO>;
             static_assert(Object::HasValue == true,
@@ -149,7 +151,7 @@ namespace rocRoller
         };
 
         template <typename Object, typename IO>
-        struct IndexMappingTraits
+        struct ROCROLLER_DECLSPEC IndexMappingTraits
         {
             using iot = IOTraits<IO>;
             static_assert(Object::HasIndex == true,
@@ -163,7 +165,7 @@ namespace rocRoller
         };
 
         template <typename Object, typename IO>
-        struct IndexValueMappingTraits
+        struct ROCROLLER_DECLSPEC IndexValueMappingTraits
         {
             using iot = IOTraits<IO>;
             static_assert(Object::HasIndex == true && Object::HasValue == true,
@@ -181,44 +183,47 @@ namespace rocRoller
                   typename IO,
                   bool HasIndex = Object::HasIndex,
                   bool HasValue = Object::HasValue>
-        struct AutoMappingTraits
+        struct ROCROLLER_DECLSPEC AutoMappingTraits
         {
         };
 
         template <typename Object, typename IO>
-        struct AutoMappingTraits<Object, IO, false, false> : public EmptyMappingTraits<Object, IO>
+        struct ROCROLLER_DECLSPEC AutoMappingTraits<Object, IO, false, false>
+            : public EmptyMappingTraits<Object, IO>
         {
         };
 
         template <typename Object, typename IO>
-        struct AutoMappingTraits<Object, IO, false, true> : public ValueMappingTraits<Object, IO>
+        struct ROCROLLER_DECLSPEC AutoMappingTraits<Object, IO, false, true>
+            : public ValueMappingTraits<Object, IO>
         {
         };
 
         template <typename Object, typename IO>
-        struct AutoMappingTraits<Object, IO, true, false> : public IndexMappingTraits<Object, IO>
+        struct ROCROLLER_DECLSPEC AutoMappingTraits<Object, IO, true, false>
+            : public IndexMappingTraits<Object, IO>
         {
         };
 
         template <typename Object, typename IO>
-        struct AutoMappingTraits<Object, IO, true, true>
+        struct ROCROLLER_DECLSPEC AutoMappingTraits<Object, IO, true, true>
             : public IndexValueMappingTraits<Object, IO>
         {
         };
 
         template <typename T, typename IO, typename Context = EmptyContext>
-        struct SubclassMappingTraits
+        struct ROCROLLER_DECLSPEC SubclassMappingTraits
         {
         };
 
         template <typename Subclass, typename IO, typename Context = EmptyContext>
-        struct PointerMappingTraits;
+        struct ROCROLLER_DECLSPEC PointerMappingTraits;
 
         /**
          * Used by AutoMappingTraits to serialize an object via a std::shared_ptr<Base> where the object is of a type derived from Base.
          */
         template <typename SubclassPtr, typename IO, typename Context>
-        struct PointerMappingTraits
+        struct ROCROLLER_DECLSPEC PointerMappingTraits
         {
             using Subclass = typename SubclassPtr::element_type;
             using iot      = IOTraits<IO>;
@@ -264,7 +269,7 @@ namespace rocRoller
          * Set Nullable to true to allow serializing `nullptr`.
          */
         template <typename SharedPtr, typename IO, typename Context, bool Nullable = false>
-        struct SharedPointerMappingTraits
+        struct ROCROLLER_DECLSPEC SharedPointerMappingTraits
         {
             using Element = typename SharedPtr::element_type;
             using iot     = IOTraits<IO>;
@@ -309,7 +314,7 @@ namespace rocRoller
         };
 
         template <typename T, typename IO, bool Flow>
-        struct BaseClassMappingTraits
+        struct ROCROLLER_DECLSPEC BaseClassMappingTraits
         {
             using iot = IOTraits<IO>;
 
@@ -330,10 +335,10 @@ namespace rocRoller
         };
 
         template <typename CRTP_Traits, typename T, typename IO, typename Context = EmptyContext>
-        struct DefaultSubclassMappingTraits;
+        struct ROCROLLER_DECLSPEC DefaultSubclassMappingTraits;
 
         template <typename CRTP_Traits, typename T, typename IO, typename Context>
-        struct DefaultSubclassMappingTraits
+        struct ROCROLLER_DECLSPEC DefaultSubclassMappingTraits
         {
             using iot         = IOTraits<IO>;
             using SubclassFn  = bool(IO&, typename std::shared_ptr<T>&, Context&);
@@ -357,7 +362,7 @@ namespace rocRoller
         };
 
         template <typename CRTP_Traits, typename T, typename IO>
-        struct DefaultSubclassMappingTraits<CRTP_Traits, T, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC DefaultSubclassMappingTraits<CRTP_Traits, T, IO, EmptyContext>
         {
             using iot         = IOTraits<IO>;
             using SubclassFn  = bool(IO&, typename std::shared_ptr<T>&);

--- a/lib/include/rocRoller/Serialization/Base_fwd.hpp
+++ b/lib/include/rocRoller/Serialization/Base_fwd.hpp
@@ -26,30 +26,32 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
     namespace Serialization
     {
         template <typename IO>
-        struct IOTraits;
+        struct ROCROLLER_DECLSPEC IOTraits;
 
         template <typename T, typename IO, typename Context>
-        struct MappingTraits;
+        struct ROCROLLER_DECLSPEC MappingTraits;
 
         template <typename T, typename IO>
-        struct EnumTraits;
+        struct ROCROLLER_DECLSPEC EnumTraits;
 
         template <typename T, typename IO>
-        struct CustomMappingTraits;
+        struct ROCROLLER_DECLSPEC CustomMappingTraits;
 
         template <typename T, typename IO>
-        struct SequenceTraits;
+        struct ROCROLLER_DECLSPEC SequenceTraits;
 
         template <typename T, typename IO>
-        struct EnumTraits;
+        struct ROCROLLER_DECLSPEC EnumTraits;
 
         template <typename Object, typename IO, typename Context>
-        struct EmptyMappingTraits;
+        struct ROCROLLER_DECLSPEC EmptyMappingTraits;
     }
 
 }

--- a/lib/include/rocRoller/Serialization/Colouring.hpp
+++ b/lib/include/rocRoller/Serialization/Colouring.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/KernelGraph/Utils.hpp>
 #include <rocRoller/Serialization/Base.hpp>
 #include <rocRoller/Serialization/Containers.hpp>
@@ -36,13 +38,13 @@ namespace rocRoller
     {
 
         template <typename IO>
-        struct CustomMappingTraits<std::map<int, int>, IO>
+        struct ROCROLLER_DECLSPEC CustomMappingTraits<std::map<int, int>, IO>
             : public DefaultCustomMappingTraits<std::map<int, int>, IO, false, true>
         {
         };
 
         template <typename IO>
-        struct MappingTraits<KernelGraph::UnrollColouring, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::UnrollColouring, IO, EmptyContext>
         {
             static const bool flow = false;
             using iot              = IOTraits<IO>;

--- a/lib/include/rocRoller/Serialization/Command.hpp
+++ b/lib/include/rocRoller/Serialization/Command.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #ifdef ROCROLLER_USE_LLVM
 #include <llvm/ObjectYAML/YAML.h>
 #endif
@@ -47,13 +49,13 @@ namespace rocRoller
     namespace Serialization
     {
         template <typename IO>
-        struct SequenceTraits<std::vector<CommandArgumentPtr>, IO>
+        struct ROCROLLER_DECLSPEC SequenceTraits<std::vector<CommandArgumentPtr>, IO>
             : public DefaultSequenceTraits<std::vector<CommandArgumentPtr>, IO, false>
         {
         };
 
         template <>
-        struct KeyConversion<ArgumentOffsetMap::key_type>
+        struct ROCROLLER_DECLSPEC KeyConversion<ArgumentOffsetMap::key_type>
         {
             static std::string toString(ArgumentOffsetMap::key_type const& value)
             {
@@ -80,13 +82,13 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct CustomMappingTraits<ArgumentOffsetMap, IO>
+        struct ROCROLLER_DECLSPEC CustomMappingTraits<ArgumentOffsetMap, IO>
             : public DefaultCustomMappingTraits<ArgumentOffsetMap, IO, false, false>
         {
         };
 
         template <typename IO>
-        struct MappingTraits<Command, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC MappingTraits<Command, IO, EmptyContext>
         {
             static const bool flow = false;
             using iot              = IOTraits<IO>;
@@ -110,7 +112,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<CommandPtr, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<CommandPtr, IO, Context>
             : public SharedPointerMappingTraits<CommandPtr, IO, Context, true>
         {
         };

--- a/lib/include/rocRoller/Serialization/Containers.hpp
+++ b/lib/include/rocRoller/Serialization/Containers.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Serialization/Base.hpp>
 #include <rocRoller/Utilities/Utils.hpp>
 
@@ -37,7 +39,7 @@ namespace rocRoller
     namespace Serialization
     {
         template <typename Key>
-        struct KeyConversion
+        struct ROCROLLER_DECLSPEC KeyConversion
         {
             static std::string toString(Key const& value)
             {
@@ -55,7 +57,7 @@ namespace rocRoller
         };
 
         template <>
-        struct KeyConversion<std::string>
+        struct ROCROLLER_DECLSPEC KeyConversion<std::string>
         {
             static std::string const& toString(std::string const& value)
             {
@@ -69,7 +71,7 @@ namespace rocRoller
         };
 
         template <typename Map, typename IO, bool Sort, bool Flow>
-        struct DefaultCustomMappingTraits
+        struct ROCROLLER_DECLSPEC DefaultCustomMappingTraits
         {
             using iot         = IOTraits<IO>;
             using key_type    = typename Map::key_type;
@@ -116,25 +118,25 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct CustomMappingTraits<std::map<std::string, std::string>, IO>
+        struct ROCROLLER_DECLSPEC CustomMappingTraits<std::map<std::string, std::string>, IO>
             : public DefaultCustomMappingTraits<std::map<std::string, std::string>, IO, false, true>
         {
         };
 
         template <typename IO>
-        struct CustomMappingTraits<std::map<std::string, double>, IO>
+        struct ROCROLLER_DECLSPEC CustomMappingTraits<std::map<std::string, double>, IO>
             : public DefaultCustomMappingTraits<std::map<std::string, double>, IO, false, true>
         {
         };
 
         template <typename IO>
-        struct CustomMappingTraits<std::map<int, double>, IO>
+        struct ROCROLLER_DECLSPEC CustomMappingTraits<std::map<int, double>, IO>
             : public DefaultCustomMappingTraits<std::map<int, double>, IO, false, true>
         {
         };
 
         template <typename Seq, typename IO, bool Flow>
-        struct DefaultSequenceTraits
+        struct ROCROLLER_DECLSPEC DefaultSequenceTraits
         {
             using Value = typename Seq::value_type;
 
@@ -158,13 +160,13 @@ namespace rocRoller
 
 #define ROCROLLER_SERIALIZE_VECTOR(flow, ...)                              \
     template <typename IO>                                                 \
-    struct SequenceTraits<std::vector<__VA_ARGS__>, IO>                    \
+    struct ROCROLLER_DECLSPEC SequenceTraits<std::vector<__VA_ARGS__>, IO> \
         : public DefaultSequenceTraits<std::vector<__VA_ARGS__>, IO, flow> \
     {                                                                      \
     }
 
         template <typename T, size_t N, typename IO>
-        struct SequenceTraits<std::array<T, N>, IO>
+        struct ROCROLLER_DECLSPEC SequenceTraits<std::array<T, N>, IO>
         {
             static const bool flow = true;
 

--- a/lib/include/rocRoller/Serialization/ControlGraph.hpp
+++ b/lib/include/rocRoller/Serialization/ControlGraph.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/CodeGen/BufferInstructionOptions.hpp>
 #include <rocRoller/DataTypes/DataTypes.hpp>
 #include <rocRoller/Graph/Hypergraph.hpp>
@@ -43,13 +45,13 @@ namespace rocRoller
     {
         template <typename T, typename IO, typename Context>
         requires(std::constructible_from<KernelGraph::ControlGraph::ControlEdge,
-                                         T>) struct MappingTraits<T, IO, Context>
+                                         T>) struct ROCROLLER_DECLSPEC MappingTraits<T, IO, Context>
             : public EmptyMappingTraits<T, IO, Context>
         {
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<BufferInstructionOptions, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<BufferInstructionOptions, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, BufferInstructionOptions& opt, Context&)
@@ -71,7 +73,8 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::SetCoordinate, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::ControlGraph::SetCoordinate, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, KernelGraph::ControlGraph::SetCoordinate& op, Context& ctx)
@@ -95,7 +98,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::ForLoopOp, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::ControlGraph::ForLoopOp, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, KernelGraph::ControlGraph::ForLoopOp& op, Context&)
@@ -120,7 +123,8 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::ConditionalOp, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::ControlGraph::ConditionalOp, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, KernelGraph::ControlGraph::ConditionalOp& op, Context&)
@@ -145,7 +149,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::AssertOp, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::ControlGraph::AssertOp, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, KernelGraph::ControlGraph::AssertOp& op, Context&)
@@ -170,7 +174,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::DoWhileOp, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::ControlGraph::DoWhileOp, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, KernelGraph::ControlGraph::DoWhileOp& op, Context&)
@@ -195,7 +199,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::UnrollOp, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::ControlGraph::UnrollOp, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, KernelGraph::ControlGraph::UnrollOp& op, Context&)
@@ -219,7 +223,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::SeedPRNG, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::ControlGraph::SeedPRNG, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, KernelGraph::ControlGraph::SeedPRNG& op, Context&)
@@ -243,7 +247,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::Assign, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::ControlGraph::Assign, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, KernelGraph::ControlGraph::Assign& op, Context&)
@@ -269,7 +273,8 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::ComputeIndex, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::ControlGraph::ComputeIndex, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, KernelGraph::ControlGraph::ComputeIndex& op, Context&)
@@ -290,15 +295,15 @@ namespace rocRoller
         };
 
         template <typename Op, typename IO, typename Context>
-        requires(
-            CIsAnyOf<Op,
-                     KernelGraph::ControlGraph::Exchange,
-                     KernelGraph::ControlGraph::LoadLinear,
-                     KernelGraph::ControlGraph::LoadTiled,
-                     KernelGraph::ControlGraph::LoadVGPR,
-                     KernelGraph::ControlGraph::LoadSGPR,
-                     KernelGraph::ControlGraph::LoadTileDirect2LDS,
-                     KernelGraph::ControlGraph::LoadLDSTile>) struct MappingTraits<Op, IO, Context>
+        requires(CIsAnyOf<Op,
+                          KernelGraph::ControlGraph::Exchange,
+                          KernelGraph::ControlGraph::LoadLinear,
+                          KernelGraph::ControlGraph::LoadTiled,
+                          KernelGraph::ControlGraph::LoadVGPR,
+                          KernelGraph::ControlGraph::LoadSGPR,
+                          KernelGraph::ControlGraph::LoadTileDirect2LDS,
+                          KernelGraph::ControlGraph::LoadLDSTile>) struct ROCROLLER_DECLSPEC
+            MappingTraits<Op, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, Op& op, Context&)
@@ -337,7 +342,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::Multiply, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::ControlGraph::Multiply, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, KernelGraph::ControlGraph::Multiply& op, Context&)
@@ -356,11 +361,11 @@ namespace rocRoller
         };
 
         template <typename Op, typename IO, typename Context>
-        requires(
-            CIsAnyOf<Op,
-                     KernelGraph::ControlGraph::StoreTiled,
-                     KernelGraph::ControlGraph::StoreSGPR,
-                     KernelGraph::ControlGraph::StoreLDSTile>) struct MappingTraits<Op, IO, Context>
+        requires(CIsAnyOf<Op,
+                          KernelGraph::ControlGraph::StoreTiled,
+                          KernelGraph::ControlGraph::StoreSGPR,
+                          KernelGraph::ControlGraph::StoreLDSTile>) struct ROCROLLER_DECLSPEC
+            MappingTraits<Op, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, Op& op, Context&)
@@ -386,7 +391,8 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::TensorContraction, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::ControlGraph::TensorContraction, IO, Context>
         {
             using iot = IOTraits<IO>;
             static void mapping(IO& io, KernelGraph::ControlGraph::TensorContraction& op, Context&)
@@ -410,14 +416,14 @@ namespace rocRoller
 
         template <typename T, typename IO, typename Context>
         requires(std::constructible_from<KernelGraph::ControlGraph::Operation, T>&& T::HasValue
-                 == false) struct MappingTraits<T, IO, Context>
+                 == false) struct ROCROLLER_DECLSPEC MappingTraits<T, IO, Context>
             : public EmptyMappingTraits<T, IO, Context>
         {
         };
 
         static_assert(CNamedVariant<KernelGraph::ControlGraph::ControlEdge>);
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::ControlEdge, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::ControlGraph::ControlEdge, IO, Context>
             : public DefaultVariantMappingTraits<KernelGraph::ControlGraph::ControlEdge,
                                                  IO,
                                                  Context>
@@ -426,14 +432,15 @@ namespace rocRoller
 
         static_assert(CNamedVariant<KernelGraph::ControlGraph::Operation>);
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::Operation, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::ControlGraph::Operation, IO, Context>
             : public DefaultVariantMappingTraits<KernelGraph::ControlGraph::Operation, IO, Context>
         {
         };
 
         static_assert(CNamedVariant<KernelGraph::ControlGraph::ControlGraph::Element>);
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::ControlGraph::Element, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::ControlGraph::ControlGraph::Element, IO, Context>
             : public DefaultVariantMappingTraits<KernelGraph::ControlGraph::ControlGraph::Element,
                                                  IO,
                                                  Context>
@@ -475,12 +482,12 @@ namespace rocRoller
         }
 
         template <typename IO>
-        struct CustomMappingTraits<CompressedTable, IO>
+        struct ROCROLLER_DECLSPEC CustomMappingTraits<CompressedTable, IO>
             : public DefaultCustomMappingTraits<CompressedTable, IO, false, false>
         {
         };
         template <typename IO>
-        struct CustomMappingTraits<CompressedTableEntry, IO>
+        struct ROCROLLER_DECLSPEC CustomMappingTraits<CompressedTableEntry, IO>
             : public DefaultCustomMappingTraits<CompressedTableEntry, IO, false, false>
         {
         };
@@ -491,7 +498,8 @@ namespace rocRoller
 #endif
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlGraph::ControlGraph, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::ControlGraph::ControlGraph, IO, Context>
         {
             using iot = IOTraits<IO>;
             using HG  = typename KernelGraph::ControlGraph::ControlGraph::Base;

--- a/lib/include/rocRoller/Serialization/ControlToCoordinateMapper.hpp
+++ b/lib/include/rocRoller/Serialization/ControlToCoordinateMapper.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/DataTypes/DataTypes.hpp>
 #include <rocRoller/Graph/Hypergraph.hpp>
 #include <rocRoller/KernelGraph/ControlToCoordinateMapper.hpp>
@@ -41,13 +43,14 @@ namespace rocRoller
     namespace Serialization
     {
         template <typename IO, typename Context>
-        struct MappingTraits<std::monostate, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<std::monostate, IO, Context>
             : public EmptyMappingTraits<std::monostate, IO, Context>
         {
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::Connections::JustNaryArgument, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::Connections::JustNaryArgument, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -66,7 +69,8 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::Connections::TypeAndSubDimension, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::Connections::TypeAndSubDimension, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -87,7 +91,8 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::Connections::TypeAndNaryArgument, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::Connections::TypeAndNaryArgument, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -108,7 +113,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::Connections::ComputeIndex, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::Connections::ComputeIndex, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -130,7 +135,8 @@ namespace rocRoller
         static_assert(CNamedVariant<KernelGraph::Connections::ConnectionSpec>);
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::Connections::ConnectionSpec, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::Connections::ConnectionSpec, IO, Context>
             : public DefaultVariantMappingTraits<KernelGraph::Connections::ConnectionSpec,
                                                  IO,
                                                  Context>
@@ -139,7 +145,8 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlToCoordinateMapper::Connection, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::ControlToCoordinateMapper::Connection, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -163,7 +170,7 @@ namespace rocRoller
         ROCROLLER_SERIALIZE_VECTOR(false, KernelGraph::ControlToCoordinateMapper::Connection);
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::ControlToCoordinateMapper, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::ControlToCoordinateMapper, IO, Context>
         {
             using iot = IOTraits<IO>;
 

--- a/lib/include/rocRoller/Serialization/CoordinateGraph.hpp
+++ b/lib/include/rocRoller/Serialization/CoordinateGraph.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/AssemblyKernel.hpp>
 #include <rocRoller/DataTypes/DataTypes.hpp>
 #include <rocRoller/Graph/Hypergraph.hpp>
@@ -42,7 +44,8 @@ namespace rocRoller
     namespace Serialization
     {
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::BaseDimension, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::CoordinateGraph::BaseDimension, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -63,7 +66,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::LDS, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::CoordinateGraph::LDS, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -85,7 +88,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::Adhoc, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::CoordinateGraph::Adhoc, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -115,7 +118,8 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::SubDimension, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::CoordinateGraph::SubDimension, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -138,7 +142,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::User, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::CoordinateGraph::User, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -161,7 +165,8 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::MacroTile, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::CoordinateGraph::MacroTile, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -188,7 +193,8 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::ThreadTile, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::CoordinateGraph::ThreadTile, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -213,7 +219,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::WaveTile, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::CoordinateGraph::WaveTile, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -240,13 +246,13 @@ namespace rocRoller
 
         template <typename T, typename IO, typename Context>
         requires(std::constructible_from<KernelGraph::CoordinateGraph::Edge, T>&& T::HasValue
-                 == false) struct MappingTraits<T, IO, Context>
+                 == false) struct ROCROLLER_DECLSPEC MappingTraits<T, IO, Context>
             : public EmptyMappingTraits<T, IO, Context>
         {
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::Index, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::CoordinateGraph::Index, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -267,7 +273,7 @@ namespace rocRoller
         template <typename T, typename IO, typename Context>
         requires(std::constructible_from<KernelGraph::CoordinateGraph::Dimension, T>&&
                      std::derived_from<T, KernelGraph::CoordinateGraph::SubDimension>&& T::HasValue
-                 == false) struct MappingTraits<T, IO, Context>
+                 == false) struct ROCROLLER_DECLSPEC MappingTraits<T, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -292,7 +298,7 @@ namespace rocRoller
                 T,
                 KernelGraph::CoordinateGraph::
                     BaseDimension> && !std::derived_from<T, KernelGraph::CoordinateGraph::SubDimension> && T::HasValue == false) struct
-            MappingTraits<T, IO, Context>
+            ROCROLLER_DECLSPEC MappingTraits<T, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -313,7 +319,8 @@ namespace rocRoller
 
         static_assert(CNamedVariant<KernelGraph::CoordinateGraph::CoordinateTransformEdge>);
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::CoordinateTransformEdge, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::CoordinateGraph::CoordinateTransformEdge, IO, Context>
             : public DefaultVariantMappingTraits<
                   KernelGraph::CoordinateGraph::CoordinateTransformEdge,
                   IO,
@@ -324,7 +331,8 @@ namespace rocRoller
         static_assert(CNamedVariant<KernelGraph::CoordinateGraph::DataFlowEdge>);
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::DataFlowEdge, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::CoordinateGraph::DataFlowEdge, IO, Context>
             : public DefaultVariantMappingTraits<KernelGraph::CoordinateGraph::DataFlowEdge,
                                                  IO,
                                                  Context>
@@ -333,14 +341,15 @@ namespace rocRoller
 
         static_assert(CNamedVariant<KernelGraph::CoordinateGraph::Edge>);
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::Edge, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::CoordinateGraph::Edge, IO, Context>
             : public DefaultVariantMappingTraits<KernelGraph::CoordinateGraph::Edge, IO, Context>
         {
         };
 
         static_assert(CNamedVariant<KernelGraph::CoordinateGraph::Dimension>);
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::Dimension, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::CoordinateGraph::Dimension, IO, Context>
             : public DefaultVariantMappingTraits<KernelGraph::CoordinateGraph::Dimension,
                                                  IO,
                                                  Context>
@@ -349,7 +358,8 @@ namespace rocRoller
 
         static_assert(CNamedVariant<KernelGraph::CoordinateGraph::CoordinateGraph::Element>);
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::CoordinateGraph::Element, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::CoordinateGraph::CoordinateGraph::Element, IO, Context>
             : public DefaultVariantMappingTraits<
                   KernelGraph::CoordinateGraph::CoordinateGraph::Element,
                   IO,
@@ -358,7 +368,8 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::CoordinateGraph::CoordinateGraph, IO, Context>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<KernelGraph::CoordinateGraph::CoordinateGraph, IO, Context>
         {
             using iot = IOTraits<IO>;
             using HG  = typename KernelGraph::CoordinateGraph::CoordinateGraph::Base;

--- a/lib/include/rocRoller/Serialization/Enum.hpp
+++ b/lib/include/rocRoller/Serialization/Enum.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <type_traits>
 
 #include <rocRoller/DataTypes/DataTypes.hpp>
@@ -40,7 +42,7 @@ namespace rocRoller
          * i.e. provides a Count value and toString (fromString() uses toString).
          */
         template <CCountedEnum Enum>
-        struct ScalarTraits<Enum>
+        struct ROCROLLER_DECLSPEC ScalarTraits<Enum>
         {
             static std::string output(const Enum& value)
             {

--- a/lib/include/rocRoller/Serialization/Expression.hpp
+++ b/lib/include/rocRoller/Serialization/Expression.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/AssemblyKernelArgument.hpp>
 #include <rocRoller/DataTypes/DataTypes.hpp>
 #include <rocRoller/Expression.hpp>
@@ -41,21 +43,21 @@ namespace rocRoller
     namespace Serialization
     {
         template <typename IO, typename Context>
-        struct MappingTraits<Expression::ExpressionPtr, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Expression::ExpressionPtr, IO, Context>
             : public SharedPointerMappingTraits<Expression::ExpressionPtr, IO, Context, true>
         {
             static const bool flow = true;
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Expression::Expression, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Expression::Expression, IO, Context>
             : public DefaultVariantMappingTraits<Expression::Expression, IO, Context>
         {
             static const bool flow = true;
         };
 
         template <Expression::CBinary TExp, typename IO, typename Context>
-        struct MappingTraits<TExp, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<TExp, IO, Context>
         {
             static const bool flow = true;
             using iot              = IOTraits<IO>;
@@ -76,7 +78,7 @@ namespace rocRoller
         };
 
         template <Expression::CUnary TExp, typename IO, typename Context>
-        struct MappingTraits<TExp, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<TExp, IO, Context>
         {
             static const bool flow = true;
             using iot              = IOTraits<IO>;
@@ -96,7 +98,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Expression::Convert, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Expression::Convert, IO, Context>
         {
             static const bool flow = true;
             using iot              = IOTraits<IO>;
@@ -117,7 +119,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Expression::BitFieldExtract, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Expression::BitFieldExtract, IO, Context>
         {
             static const bool flow = true;
             using iot              = IOTraits<IO>;
@@ -140,7 +142,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Expression::ScaledMatrixMultiply, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Expression::ScaledMatrixMultiply, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -163,7 +165,7 @@ namespace rocRoller
         };
 
         template <Expression::CTernary TExp, typename IO, typename Context>
-        struct MappingTraits<TExp, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<TExp, IO, Context>
         {
             static const bool flow = true;
             using iot              = IOTraits<IO>;
@@ -186,7 +188,7 @@ namespace rocRoller
 
         static_assert(CNamedVariant<CommandArgumentValue>);
         template <typename IO, typename Context>
-        struct MappingTraits<CommandArgumentValue, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<CommandArgumentValue, IO, Context>
             : public DefaultVariantMappingTraits<CommandArgumentValue, IO, Context>
         {
             static const bool flow = true;
@@ -236,7 +238,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<CommandArgumentPtr, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<CommandArgumentPtr, IO, Context>
         {
             static const bool flow = true;
             using iot              = IOTraits<IO>;
@@ -281,7 +283,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<VariableType, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<VariableType, IO, Context>
         {
             static const bool flow = true;
             using iot              = IOTraits<IO>;
@@ -302,7 +304,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Register::Value, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Register::Value, IO, Context>
         {
             static const bool flow = true;
             using iot              = IOTraits<IO>;
@@ -335,14 +337,14 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Register::ValuePtr, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Register::ValuePtr, IO, Context>
             : public SharedPointerMappingTraits<Register::ValuePtr, IO, Context, true>
         {
             static const bool flow = true;
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<AssemblyKernelArgumentPtr, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<AssemblyKernelArgumentPtr, IO, Context>
         {
             static const bool flow = true;
             using iot              = IOTraits<IO>;
@@ -370,7 +372,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Expression::DataFlowTag, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Expression::DataFlowTag, IO, Context>
         {
             static const bool flow = true;
             using iot              = IOTraits<IO>;
@@ -392,7 +394,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Expression::WaveTilePtr, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Expression::WaveTilePtr, IO, Context>
         {
             static const bool flow = true;
             using iot              = IOTraits<IO>;

--- a/lib/include/rocRoller/Serialization/GPUArchitecture.hpp
+++ b/lib/include/rocRoller/Serialization/GPUArchitecture.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #ifdef ROCROLLER_USE_LLVM
 #include <llvm/ObjectYAML/YAML.h>
 #endif
@@ -61,7 +63,7 @@ namespace rocRoller
          * generic enum serialization.
          */
         template <>
-        struct ScalarTraits<GPUWaitQueueType>
+        struct ROCROLLER_DECLSPEC ScalarTraits<GPUWaitQueueType>
         {
             static std::string output(const GPUWaitQueueType& value)
             {
@@ -75,7 +77,7 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct MappingTraits<GPUCapability, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC MappingTraits<GPUCapability, IO, EmptyContext>
         {
             static const bool flow = false;
             using iot              = IOTraits<IO>;
@@ -92,7 +94,7 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct MappingTraits<GPUArchitectureTarget, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC MappingTraits<GPUArchitectureTarget, IO, EmptyContext>
         {
             static const bool flow = false;
             using iot              = IOTraits<IO>;
@@ -111,7 +113,7 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct MappingTraits<GPUInstructionInfo, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC MappingTraits<GPUInstructionInfo, IO, EmptyContext>
         {
             static const bool flow = true;
             using iot              = IOTraits<IO>;
@@ -134,7 +136,7 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct MappingTraits<GPUArchitecture, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC MappingTraits<GPUArchitecture, IO, EmptyContext>
         {
             static const bool flow = false;
             using iot              = IOTraits<IO>;
@@ -153,7 +155,7 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct MappingTraits<GPUArchitecturesStruct, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC MappingTraits<GPUArchitecturesStruct, IO, EmptyContext>
         {
             static const bool flow = false;
             using iot              = IOTraits<IO>;
@@ -170,7 +172,7 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct CustomMappingTraits<std::map<std::string, GPUInstructionInfo>, IO>
+        struct ROCROLLER_DECLSPEC CustomMappingTraits<std::map<std::string, GPUInstructionInfo>, IO>
             : public DefaultCustomMappingTraits<std::map<std::string, GPUInstructionInfo>,
                                                 IO,
                                                 false,
@@ -179,13 +181,14 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct CustomMappingTraits<std::map<GPUCapability, int>, IO>
+        struct ROCROLLER_DECLSPEC CustomMappingTraits<std::map<GPUCapability, int>, IO>
             : public DefaultCustomMappingTraits<std::map<GPUCapability, int>, IO, false, true>
         {
         };
 
         template <typename IO>
-        struct CustomMappingTraits<std::map<GPUArchitectureTarget, GPUArchitecture>, IO>
+        struct ROCROLLER_DECLSPEC
+            CustomMappingTraits<std::map<GPUArchitectureTarget, GPUArchitecture>, IO>
             : public DefaultCustomMappingTraits<std::map<GPUArchitectureTarget, GPUArchitecture>,
                                                 IO,
                                                 false,

--- a/lib/include/rocRoller/Serialization/HasTraits.hpp
+++ b/lib/include/rocRoller/Serialization/HasTraits.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Serialization/Base.hpp>
 
 #include <cstddef>
@@ -35,7 +37,7 @@ namespace rocRoller
     namespace Serialization
     {
         template <typename T, T>
-        struct SameType;
+        struct ROCROLLER_DECLSPEC SameType;
 
         template <typename T, typename IO, typename Context = EmptyContext>
         concept CMappedType = requires(T& obj, IO& io, Context& ctx)
@@ -50,13 +52,13 @@ namespace rocRoller
         };
 
         template <typename T, typename IO, typename Context = EmptyContext>
-        struct has_MappingTraits
+        struct ROCROLLER_DECLSPEC has_MappingTraits
         {
             static const bool value = CMappedType<T, IO, Context>;
         };
 
         template <typename T, typename IO, typename Context = EmptyContext>
-        struct has_EmptyMappingTraits
+        struct ROCROLLER_DECLSPEC has_EmptyMappingTraits
         {
             static const bool value
                 = std::same_as<Context, EmptyContext> && CEmptyMappedType<T, IO, Context>;
@@ -67,7 +69,7 @@ namespace rocRoller
             value && !has_MappingTraits<T, IO, Context>::value;
 
         template <typename T, typename IO>
-        class has_EnumTraits
+        class ROCROLLER_DECLSPEC has_EnumTraits
         {
             using enumeration = void (*)(IO&, T&);
 
@@ -96,7 +98,7 @@ namespace rocRoller
         };
 
         template <typename T, typename IO>
-        class has_SequenceTraits
+        class ROCROLLER_DECLSPEC has_SequenceTraits
         {
             using size = size_t (*)(IO&, T&);
 
@@ -114,7 +116,7 @@ namespace rocRoller
         concept SequenceType = has_SequenceTraits<T, IO>::value;
 
         template <typename T, typename IO>
-        class has_CustomMappingTraits
+        class ROCROLLER_DECLSPEC has_CustomMappingTraits
         {
             using inputOne = void (*)(IO&, std::string const&, T&);
             using output   = void (*)(IO&, T&);
@@ -134,7 +136,7 @@ namespace rocRoller
         concept CustomMappingType = has_CustomMappingTraits<T, IO>::value;
 
         template <typename T, typename IO>
-        struct has_SerializationTraits
+        struct ROCROLLER_DECLSPEC has_SerializationTraits
         {
             static const bool value0
                 = has_EmptyMappingTraits<T, IO>::value || has_MappingTraits<T, IO>::value;
@@ -165,13 +167,13 @@ namespace rocRoller
         };
 
         template <typename T>
-        struct HasFlowValue
+        struct ROCROLLER_DECLSPEC HasFlowValue
         {
             static const bool flow = false;
         };
 
         template <CHasFlowMember T>
-        struct HasFlowValue<T>
+        struct ROCROLLER_DECLSPEC HasFlowValue<T>
         {
             static const bool flow = T::flow;
         };

--- a/lib/include/rocRoller/Serialization/Hypergraph.hpp
+++ b/lib/include/rocRoller/Serialization/Hypergraph.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/DataTypes/DataTypes.hpp>
 #include <rocRoller/Graph/Hypergraph.hpp>
 #include <rocRoller/Serialization/AssemblyKernel.hpp>
@@ -40,7 +42,7 @@ namespace rocRoller
     namespace Serialization
     {
         template <typename IO>
-        struct MappingTraits<Graph::HypergraphIncident, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC MappingTraits<Graph::HypergraphIncident, IO, EmptyContext>
         {
             using iot              = IOTraits<IO>;
             static const bool flow = true;
@@ -61,14 +63,14 @@ namespace rocRoller
         ROCROLLER_SERIALIZE_VECTOR(false, Graph::HypergraphIncident);
 
         template <CNamedVariant Var>
-        struct ElementEntry
+        struct ROCROLLER_DECLSPEC ElementEntry
         {
             int id;
             Var value;
         };
 
         template <CNamedVariant Var, typename IO, typename Context>
-        struct MappingTraits<ElementEntry<Var>, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<ElementEntry<Var>, IO, Context>
         {
             using iot   = IOTraits<IO>;
             using Entry = ElementEntry<Var>;
@@ -90,7 +92,7 @@ namespace rocRoller
         };
 
         template <CNamedVariant Var, typename IO>
-        struct SequenceTraits<std::vector<ElementEntry<Var>>, IO>
+        struct ROCROLLER_DECLSPEC SequenceTraits<std::vector<ElementEntry<Var>>, IO>
             : public DefaultSequenceTraits<std::vector<ElementEntry<Var>>, IO, false>
         {
         };
@@ -102,7 +104,8 @@ namespace rocRoller
         // };
 
         template <typename Node, typename Edge, bool Hyper, typename IO>
-        struct MappingTraits<Graph::Hypergraph<Node, Edge, Hyper>, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC
+            MappingTraits<Graph::Hypergraph<Node, Edge, Hyper>, IO, EmptyContext>
         {
             using iot     = IOTraits<IO>;
             using HG      = Graph::Hypergraph<Node, Edge, Hyper>;

--- a/lib/include/rocRoller/Serialization/KernelGraph.hpp
+++ b/lib/include/rocRoller/Serialization/KernelGraph.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #ifdef ROCROLLER_USE_LLVM
 #include <llvm/ObjectYAML/YAML.h>
 #endif
@@ -44,7 +46,7 @@ namespace rocRoller
     {
 
         template <typename IO>
-        struct MappingTraits<KernelGraph::KernelGraph, IO, EmptyContext>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::KernelGraph, IO, EmptyContext>
         {
             static const bool flow = false;
             using iot              = IOTraits<IO>;
@@ -63,7 +65,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<KernelGraph::KernelGraphPtr, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<KernelGraph::KernelGraphPtr, IO, Context>
             : public SharedPointerMappingTraits<KernelGraph::KernelGraphPtr, IO, Context, true>
         {
         };

--- a/lib/include/rocRoller/Serialization/Operations.hpp
+++ b/lib/include/rocRoller/Serialization/Operations.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #ifdef ROCROLLER_USE_LLVM
 #include <llvm/ObjectYAML/YAML.h>
 #endif
@@ -45,7 +47,7 @@ namespace rocRoller
     namespace Serialization
     {
         template <>
-        struct ScalarTraits<Operations::OperationTag>
+        struct ROCROLLER_DECLSPEC ScalarTraits<Operations::OperationTag>
         {
             static std::string output(Operations::OperationTag const& x)
             {
@@ -62,13 +64,13 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct SequenceTraits<std::vector<Operations::OperationTag>, IO>
+        struct ROCROLLER_DECLSPEC SequenceTraits<std::vector<Operations::OperationTag>, IO>
             : public DefaultSequenceTraits<std::vector<Operations::OperationTag>, IO, true>
         {
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::Tensor, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::Tensor, IO, Context>
         {
             using TOp = Operations::Tensor;
             using iot = IOTraits<IO>;
@@ -94,7 +96,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::Scalar, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::Scalar, IO, Context>
         {
             using TOp = Operations::Scalar;
             using iot = IOTraits<IO>;
@@ -115,7 +117,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::Literal, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::Literal, IO, Context>
         {
             using TOp = Operations::Literal;
             using iot = IOTraits<IO>;
@@ -135,7 +137,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::BlockScale, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::BlockScale, IO, Context>
         {
             using TOp = Operations::BlockScale;
             using iot = IOTraits<IO>;
@@ -170,7 +172,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::T_Load_Linear, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::T_Load_Linear, IO, Context>
         {
             using TOp = Operations::T_Load_Linear;
             using iot = IOTraits<IO>;
@@ -190,7 +192,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::T_Load_Scalar, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::T_Load_Scalar, IO, Context>
         {
             using TOp = Operations::T_Load_Scalar;
             using iot = IOTraits<IO>;
@@ -210,7 +212,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::T_Load_Tiled, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::T_Load_Tiled, IO, Context>
         {
             using TOp = Operations::T_Load_Tiled;
             using iot = IOTraits<IO>;
@@ -230,7 +232,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::T_Mul, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::T_Mul, IO, Context>
         {
             using TOp = Operations::T_Mul;
             using iot = IOTraits<IO>;
@@ -251,7 +253,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::T_Store_Linear, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::T_Store_Linear, IO, Context>
         {
             using TOp = Operations::T_Store_Linear;
             using iot = IOTraits<IO>;
@@ -272,7 +274,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::T_Store_Tiled, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::T_Store_Tiled, IO, Context>
         {
             using TOp = Operations::T_Store_Tiled;
             using iot = IOTraits<IO>;
@@ -293,7 +295,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::Nop, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::Nop, IO, Context>
         {
             using TOp = Operations::Nop;
             using iot = IOTraits<IO>;
@@ -310,7 +312,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::RandomNumberGenerator, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::RandomNumberGenerator, IO, Context>
         {
             using TOp = Operations::RandomNumberGenerator;
             using iot = IOTraits<IO>;
@@ -332,7 +334,7 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::T_Execute, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::T_Execute, IO, Context>
         {
             using TOp = Operations::T_Execute;
             using iot = IOTraits<IO>;
@@ -375,7 +377,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::Operation>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::Operation, Operations::Operation>
         {
             static Operations::Operation call()
             {
@@ -384,7 +386,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::Tensor>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::Operation, Operations::Tensor>
         {
             static Operations::Operation call()
             {
@@ -393,7 +395,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::Scalar>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::Operation, Operations::Scalar>
         {
             static Operations::Operation call()
             {
@@ -402,7 +404,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::Literal>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::Operation, Operations::Literal>
         {
             static Operations::Operation call()
             {
@@ -411,7 +413,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::BlockScale>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::Operation, Operations::BlockScale>
         {
             static Operations::Operation call()
             {
@@ -420,7 +422,8 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::RandomNumberGenerator>
+        struct ROCROLLER_DECLSPEC
+            DefaultConstruct<Operations::Operation, Operations::RandomNumberGenerator>
         {
             static Operations::Operation call()
             {
@@ -429,7 +432,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::T_Load_Linear>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::Operation, Operations::T_Load_Linear>
         {
             static Operations::Operation call()
             {
@@ -438,7 +441,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::T_Load_Scalar>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::Operation, Operations::T_Load_Scalar>
         {
             static Operations::Operation call()
             {
@@ -447,7 +450,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::T_Load_Tiled>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::Operation, Operations::T_Load_Tiled>
         {
             static Operations::Operation call()
             {
@@ -456,7 +459,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::T_Mul>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::Operation, Operations::T_Mul>
         {
             static Operations::Operation call()
             {
@@ -466,7 +469,8 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::T_Store_Linear>
+        struct ROCROLLER_DECLSPEC
+            DefaultConstruct<Operations::Operation, Operations::T_Store_Linear>
         {
             static Operations::Operation call()
             {
@@ -476,7 +480,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::T_Store_Tiled>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::Operation, Operations::T_Store_Tiled>
         {
             static Operations::Operation call()
             {
@@ -486,7 +490,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::T_Execute>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::Operation, Operations::T_Execute>
         {
             static Operations::Operation call()
             {
@@ -495,7 +499,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::Operation, Operations::Nop>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::Operation, Operations::Nop>
         {
             static Operations::Operation call()
             {
@@ -504,13 +508,13 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::Operation, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::Operation, IO, Context>
             : public DefaultVariantMappingTraits<Operations::Operation, IO, Context>
         {
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<std::shared_ptr<Operations::Operation>, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<std::shared_ptr<Operations::Operation>, IO, Context>
             : public SharedPointerMappingTraits<std::shared_ptr<Operations::Operation>,
                                                 IO,
                                                 Context,
@@ -519,7 +523,8 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct SequenceTraits<std::vector<std::shared_ptr<Operations::Operation>>, IO>
+        struct ROCROLLER_DECLSPEC
+            SequenceTraits<std::vector<std::shared_ptr<Operations::Operation>>, IO>
             : public DefaultSequenceTraits<std::vector<std::shared_ptr<Operations::Operation>>,
                                            IO,
                                            false>

--- a/lib/include/rocRoller/Serialization/Variant.hpp
+++ b/lib/include/rocRoller/Serialization/Variant.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <variant>
 
 #include <rocRoller/Serialization/Base.hpp>
@@ -57,7 +59,7 @@ namespace rocRoller
         };
 
         template <typename T>
-        struct VariantTypeKeySpecifier
+        struct ROCROLLER_DECLSPEC VariantTypeKeySpecifier
         {
             static std::string TypeKey()
             {
@@ -111,7 +113,7 @@ namespace rocRoller
          * allows the Adhoc dimension to use this for its `m_name` field.
          */
         template <CNamedVariant T, typename IO, typename Context = EmptyContext>
-        struct DefaultVariantMappingTraits
+        struct ROCROLLER_DECLSPEC DefaultVariantMappingTraits
         {
             using iot            = IOTraits<IO>;
             using AlternativeFn  = std::function<T(void)>;
@@ -217,7 +219,7 @@ namespace rocRoller
             DefaultVariantMappingTraits<T, IO, Context>::alternatives
             = DefaultVariantMappingTraits<T, IO, Context>::GetAlternatives();
 
-        struct RemainingTypePathVisitor
+        struct ROCROLLER_DECLSPEC RemainingTypePathVisitor
         {
             template <CNamedVariant Var>
             std::string operator()(Var const& v)

--- a/lib/include/rocRoller/Serialization/XOps.hpp
+++ b/lib/include/rocRoller/Serialization/XOps.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #ifdef ROCROLLER_USE_LLVM
 #include <llvm/ObjectYAML/YAML.h>
 #endif
@@ -43,7 +45,7 @@ namespace rocRoller
     {
 
         template <Operations::CUnaryXOp TOp, typename IO, typename Context>
-        struct MappingTraits<TOp, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<TOp, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -62,7 +64,7 @@ namespace rocRoller
         };
 
         template <Operations::CBinaryXOp TOp, typename IO, typename Context>
-        struct MappingTraits<TOp, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<TOp, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -82,7 +84,7 @@ namespace rocRoller
         };
 
         template <Operations::CTernaryXOp TOp, typename IO, typename Context>
-        struct MappingTraits<TOp, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<TOp, IO, Context>
         {
             using iot = IOTraits<IO>;
 
@@ -103,7 +105,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_Neg>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_Neg>
         {
             static Operations::XOp call()
             {
@@ -112,7 +114,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_Abs>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_Abs>
         {
             static Operations::XOp call()
             {
@@ -121,7 +123,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_Not>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_Not>
         {
             static Operations::XOp call()
             {
@@ -130,7 +132,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_Cvt>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_Cvt>
         {
             static Operations::XOp call()
             {
@@ -139,7 +141,8 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_StochasticRoundingCvt>
+        struct ROCROLLER_DECLSPEC
+            DefaultConstruct<Operations::XOp, Operations::E_StochasticRoundingCvt>
         {
             static Operations::XOp call()
             {
@@ -149,7 +152,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_Add>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_Add>
         {
             static Operations::XOp call()
             {
@@ -159,7 +162,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_Sub>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_Sub>
         {
             static Operations::XOp call()
             {
@@ -169,7 +172,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_Mul>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_Mul>
         {
             static Operations::XOp call()
             {
@@ -179,7 +182,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_Div>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_Div>
         {
             static Operations::XOp call()
             {
@@ -189,7 +192,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_And>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_And>
         {
             static Operations::XOp call()
             {
@@ -199,7 +202,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_Or>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_Or>
         {
             static Operations::XOp call()
             {
@@ -208,7 +211,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_GreaterThan>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_GreaterThan>
         {
             static Operations::XOp call()
             {
@@ -218,7 +221,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_Conditional>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_Conditional>
         {
             static Operations::XOp call()
             {
@@ -229,7 +232,7 @@ namespace rocRoller
         };
 
         template <>
-        struct DefaultConstruct<Operations::XOp, Operations::E_RandomNumber>
+        struct ROCROLLER_DECLSPEC DefaultConstruct<Operations::XOp, Operations::E_RandomNumber>
         {
             static Operations::XOp call()
             {
@@ -238,13 +241,13 @@ namespace rocRoller
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<Operations::XOp, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<Operations::XOp, IO, Context>
             : public DefaultVariantMappingTraits<Operations::XOp, IO, Context>
         {
         };
 
         template <typename IO, typename Context>
-        struct MappingTraits<std::shared_ptr<Operations::XOp>, IO, Context>
+        struct ROCROLLER_DECLSPEC MappingTraits<std::shared_ptr<Operations::XOp>, IO, Context>
         {
             using TOp = std::shared_ptr<Operations::XOp>;
             using iot = IOTraits<IO>;
@@ -267,7 +270,7 @@ namespace rocRoller
         };
 
         template <typename IO>
-        struct SequenceTraits<std::vector<std::shared_ptr<Operations::XOp>>, IO>
+        struct ROCROLLER_DECLSPEC SequenceTraits<std::vector<std::shared_ptr<Operations::XOp>>, IO>
             : public DefaultSequenceTraits<std::vector<std::shared_ptr<Operations::XOp>>, IO, false>
         {
         };

--- a/lib/include/rocRoller/Serialization/llvm/YAML.hpp
+++ b/lib/include/rocRoller/Serialization/llvm/YAML.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Serialization/Base.hpp>
 #include <rocRoller/Serialization/HasTraits.hpp>
 
@@ -69,18 +71,18 @@ namespace llvm
          */
 
         template <typename T>
-        struct FlowBase
+        struct ROCROLLER_DECLSPEC FlowBase
         {
         };
 
         template <sn::CHasFlow T>
-        struct FlowBase<T>
+        struct ROCROLLER_DECLSPEC FlowBase<T>
         {
             static const bool flow = true;
         };
 
         template <typename T>
-        requires(sn::has_SequenceTraits<T, IO>::value) struct SequenceTraits<T>
+        requires(sn::has_SequenceTraits<T, IO>::value) struct ROCROLLER_DECLSPEC SequenceTraits<T>
             : public FlowBase<sn::SequenceTraits<T, IO>>
         {
             static size_t size(IO& io, T& seq)
@@ -95,7 +97,8 @@ namespace llvm
         };
 
         template <typename T>
-        requires(sn::has_EnumTraits<T, IO>::value) struct ScalarEnumerationTraits<T>
+        requires(sn::has_EnumTraits<T, IO>::value) struct ROCROLLER_DECLSPEC
+            ScalarEnumerationTraits<T>
         {
             static void enumeration(IO& io, T& value)
             {
@@ -104,7 +107,8 @@ namespace llvm
         };
 
         template <typename T, typename Context>
-        requires(sn::has_MappingTraits<T, IO>::value) struct MappingContextTraits<T, Context>
+        requires(sn::has_MappingTraits<T, IO>::value) struct ROCROLLER_DECLSPEC
+            MappingContextTraits<T, Context>
         {
             static void mapping(IO& io, T& obj, Context& ctx)
             {
@@ -119,8 +123,8 @@ namespace llvm
         };
 
         template <typename T>
-        requires(sn::has_EmptyMappingTraits<T, IO>::value) struct MappingTraits<T>
-            : public FlowBase<sn::MappingTraits<T, IO, EmptyContext>>
+        requires(sn::has_EmptyMappingTraits<T, IO>::value) struct ROCROLLER_DECLSPEC
+            MappingTraits<T> : public FlowBase<sn::MappingTraits<T, IO, EmptyContext>>
         {
             static void mapping(IO& io, T& obj)
             {
@@ -135,7 +139,8 @@ namespace llvm
         };
 
         template <typename T>
-        requires(sn::has_CustomMappingTraits<T, IO>::value) struct CustomMappingTraits<T>
+        requires(sn::has_CustomMappingTraits<T, IO>::value) struct ROCROLLER_DECLSPEC
+            CustomMappingTraits<T>
         {
             using Impl = sn::CustomMappingTraits<T, IO>;
 
@@ -151,7 +156,7 @@ namespace llvm
         };
 
         template <typename T>
-        struct Hide
+        struct ROCROLLER_DECLSPEC Hide
         {
             T& value;
 
@@ -173,7 +178,7 @@ namespace rocRoller
     namespace Serialization
     {
         template <>
-        struct IOTraits<llvm::yaml::IO>
+        struct ROCROLLER_DECLSPEC IOTraits<llvm::yaml::IO>
         {
             using IO = llvm::yaml::IO;
 
@@ -249,7 +254,7 @@ namespace llvm
             = std::conditional<std::is_same<size_t, uint64_t>::value, FooType, size_t>::type;
 
         template <>
-        struct ScalarTraits<mysize_t>
+        struct ROCROLLER_DECLSPEC ScalarTraits<mysize_t>
         {
             static void output(const mysize_t& value, void* ctx, raw_ostream& stream)
             {
@@ -272,7 +277,7 @@ namespace llvm
         };
 
         template <typename T>
-        struct MappingTraits<Hide<T>>
+        struct ROCROLLER_DECLSPEC MappingTraits<Hide<T>>
         {
             static void mapping(IO& io, Hide<T>& value)
             {
@@ -283,7 +288,7 @@ namespace llvm
         };
 
         template <typename T>
-        struct SequenceTraits<Hide<T>>
+        struct ROCROLLER_DECLSPEC SequenceTraits<Hide<T>>
         {
             using Impl  = sn::SequenceTraits<T, IO>;
             using Value = typename Impl::Value;
@@ -301,7 +306,7 @@ namespace llvm
         };
 
         template <typename T>
-        struct ScalarEnumerationTraits<Hide<T>>
+        struct ROCROLLER_DECLSPEC ScalarEnumerationTraits<Hide<T>>
         {
             static void enumeration(IO& io, Hide<T>& value)
             {
@@ -310,7 +315,7 @@ namespace llvm
         };
 
         template <typename T>
-        struct CustomMappingTraits<Hide<T>>
+        struct ROCROLLER_DECLSPEC CustomMappingTraits<Hide<T>>
         {
             using Impl = sn::CustomMappingTraits<T, IO>;
 
@@ -336,7 +341,7 @@ namespace llvm
                                      rocRoller::BF8,
                                      rocRoller::FP6,
                                      rocRoller::BF6,
-                                     rocRoller::FP4>) struct ScalarTraits<T>
+                                     rocRoller::FP4>) struct ROCROLLER_DECLSPEC ScalarTraits<T>
         {
             static void output(const T& value, void* ctx, llvm::raw_ostream& out)
             {
@@ -362,7 +367,7 @@ namespace llvm
         };
 
         template <rocRoller::Serialization::CHasScalarTraits Scalar>
-        struct ScalarTraits<Scalar>
+        struct ROCROLLER_DECLSPEC ScalarTraits<Scalar>
         {
             using rrTraits = rocRoller::Serialization::ScalarTraits<Scalar>;
 

--- a/lib/include/rocRoller/Serialization/msgpack/Msgpack.hpp
+++ b/lib/include/rocRoller/Serialization/msgpack/Msgpack.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/GPUArchitecture/GPUArchitecture.hpp>
 #include <rocRoller/GPUArchitecture/GPUArchitectureTarget.hpp>
 #include <rocRoller/GPUArchitecture/GPUCapability.hpp>
@@ -40,7 +42,7 @@ namespace msgpack
         namespace adaptor
         {
             template <>
-            struct convert<rocRoller::GPUArchitecture>
+            struct ROCROLLER_DECLSPEC convert<rocRoller::GPUArchitecture>
             {
                 msgpack::object const& operator()(msgpack::object const&      o,
                                                   rocRoller::GPUArchitecture& v) const
@@ -64,7 +66,7 @@ namespace msgpack
             };
 
             template <>
-            struct pack<rocRoller::GPUArchitecture>
+            struct ROCROLLER_DECLSPEC pack<rocRoller::GPUArchitecture>
             {
                 template <typename Stream>
                 packer<Stream>& operator()(msgpack::packer<Stream>&          o,
@@ -79,7 +81,7 @@ namespace msgpack
             };
 
             template <>
-            struct convert<rocRoller::GPUArchitectureTarget>
+            struct ROCROLLER_DECLSPEC convert<rocRoller::GPUArchitectureTarget>
             {
                 msgpack::object const& operator()(msgpack::object const&            o,
                                                   rocRoller::GPUArchitectureTarget& v) const
@@ -99,7 +101,7 @@ namespace msgpack
             };
 
             template <>
-            struct pack<rocRoller::GPUArchitectureTarget>
+            struct ROCROLLER_DECLSPEC pack<rocRoller::GPUArchitectureTarget>
             {
                 template <typename Stream>
                 packer<Stream>& operator()(msgpack::packer<Stream>&                o,
@@ -112,7 +114,7 @@ namespace msgpack
             };
 
             template <>
-            struct convert<rocRoller::GPUArchitectureGFX>
+            struct ROCROLLER_DECLSPEC convert<rocRoller::GPUArchitectureGFX>
             {
                 msgpack::object const& operator()(msgpack::object const&         o,
                                                   rocRoller::GPUArchitectureGFX& v) const
@@ -131,7 +133,7 @@ namespace msgpack
             };
 
             template <>
-            struct pack<rocRoller::GPUArchitectureGFX>
+            struct ROCROLLER_DECLSPEC pack<rocRoller::GPUArchitectureGFX>
             {
                 template <typename Stream>
                 packer<Stream>& operator()(msgpack::packer<Stream>&             o,
@@ -144,7 +146,7 @@ namespace msgpack
             };
 
             template <>
-            struct convert<rocRoller::GPUCapability>
+            struct ROCROLLER_DECLSPEC convert<rocRoller::GPUCapability>
             {
                 msgpack::object const& operator()(msgpack::object const&    o,
                                                   rocRoller::GPUCapability& v) const
@@ -163,7 +165,7 @@ namespace msgpack
             };
 
             template <>
-            struct pack<rocRoller::GPUCapability>
+            struct ROCROLLER_DECLSPEC pack<rocRoller::GPUCapability>
             {
                 template <typename Stream>
                 packer<Stream>& operator()(msgpack::packer<Stream>&        o,
@@ -176,7 +178,7 @@ namespace msgpack
             };
 
             template <>
-            struct convert<rocRoller::GPUInstructionInfo>
+            struct ROCROLLER_DECLSPEC convert<rocRoller::GPUInstructionInfo>
             {
                 msgpack::object const& operator()(msgpack::object const&         o,
                                                   rocRoller::GPUInstructionInfo& v) const
@@ -202,7 +204,7 @@ namespace msgpack
             };
 
             template <>
-            struct pack<rocRoller::GPUInstructionInfo>
+            struct ROCROLLER_DECLSPEC pack<rocRoller::GPUInstructionInfo>
             {
                 template <typename Stream>
                 packer<Stream>& operator()(msgpack::packer<Stream>&             o,
@@ -221,7 +223,7 @@ namespace msgpack
             };
 
             template <>
-            struct convert<rocRoller::GPUWaitQueueType>
+            struct ROCROLLER_DECLSPEC convert<rocRoller::GPUWaitQueueType>
             {
                 msgpack::object const& operator()(msgpack::object const&       o,
                                                   rocRoller::GPUWaitQueueType& v) const
@@ -240,7 +242,7 @@ namespace msgpack
             };
 
             template <>
-            struct pack<rocRoller::GPUWaitQueueType>
+            struct ROCROLLER_DECLSPEC pack<rocRoller::GPUWaitQueueType>
             {
                 template <typename Stream>
                 packer<Stream>& operator()(msgpack::packer<Stream>&           o,

--- a/lib/include/rocRoller/Serialization/yaml-cpp/YAML.hpp
+++ b/lib/include/rocRoller/Serialization/yaml-cpp/YAML.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <rocRoller/Serialization/Base.hpp>
 #include <rocRoller/Serialization/Containers.hpp>
 #include <rocRoller/Serialization/HasTraits.hpp>
@@ -40,7 +42,7 @@ namespace rocRoller
 {
     namespace Serialization
     {
-        struct EmitterOutput
+        struct ROCROLLER_DECLSPEC EmitterOutput
         {
             YAML::Emitter* emitter;
             void*          context;
@@ -207,7 +209,7 @@ namespace rocRoller
         }
 
         template <>
-        struct IOTraits<EmitterOutput>
+        struct ROCROLLER_DECLSPEC IOTraits<EmitterOutput>
         {
             using IO = EmitterOutput;
 
@@ -292,7 +294,7 @@ namespace rocRoller
             val.data = floatVal;
         }
 
-        struct NodeInput
+        struct ROCROLLER_DECLSPEC NodeInput
         {
             YAML::Node* node;
             void*       context;
@@ -372,7 +374,7 @@ namespace rocRoller
         };
 
         template <>
-        struct IOTraits<NodeInput>
+        struct ROCROLLER_DECLSPEC IOTraits<NodeInput>
         {
             using IO = NodeInput;
 
@@ -436,7 +438,7 @@ namespace rocRoller
 namespace YAML
 {
     template <>
-    struct convert<rocRoller::BFloat16>
+    struct ROCROLLER_DECLSPEC convert<rocRoller::BFloat16>
     {
         static Node encode(const rocRoller::BFloat16& rhs)
         {
@@ -458,7 +460,7 @@ namespace YAML
     };
 
     template <>
-    struct convert<rocRoller::FP8>
+    struct ROCROLLER_DECLSPEC convert<rocRoller::FP8>
     {
         static Node encode(const rocRoller::FP8& rhs)
         {
@@ -480,7 +482,7 @@ namespace YAML
     };
 
     template <>
-    struct convert<rocRoller::BF8>
+    struct ROCROLLER_DECLSPEC convert<rocRoller::BF8>
     {
         static Node encode(const rocRoller::BF8& rhs)
         {
@@ -502,7 +504,7 @@ namespace YAML
     };
 
     template <>
-    struct convert<rocRoller::FP6>
+    struct ROCROLLER_DECLSPEC convert<rocRoller::FP6>
     {
         static Node encode(const rocRoller::FP6& rhs)
         {
@@ -524,7 +526,7 @@ namespace YAML
     };
 
     template <>
-    struct convert<rocRoller::BF6>
+    struct ROCROLLER_DECLSPEC convert<rocRoller::BF6>
     {
         static Node encode(const rocRoller::BF6& rhs)
         {
@@ -546,7 +548,7 @@ namespace YAML
     };
 
     template <>
-    struct convert<rocRoller::FP4>
+    struct ROCROLLER_DECLSPEC convert<rocRoller::FP4>
     {
         static Node encode(const rocRoller::FP4& rhs)
         {

--- a/lib/include/rocRoller/TensorDescriptor.hpp
+++ b/lib/include/rocRoller/TensorDescriptor.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <numeric>
 
 #include <rocRoller/CommandSolution.hpp>
@@ -38,7 +40,7 @@ namespace rocRoller
      * Describes a tensor including dimensions, memory layout, and data type.
      * Decoupled from any particular pointer value or memory location.
      */
-    class TensorDescriptor
+    class ROCROLLER_DECLSPEC TensorDescriptor
     {
     public:
         TensorDescriptor()

--- a/lib/include/rocRoller/Utilities/Comparison.hpp
+++ b/lib/include/rocRoller/Utilities/Comparison.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <type_traits>
 
 namespace rocRoller
@@ -85,7 +87,7 @@ namespace rocRoller
  *  -  1: rhs is lesser
  */
     template <typename T, typename U = T>
-    struct Comparison
+    struct ROCROLLER_DECLSPEC Comparison
     {
         enum
         {
@@ -187,7 +189,7 @@ namespace rocRoller
     }
 
     template <size_t N, class... Types>
-    struct tuple_hash
+    struct ROCROLLER_DECLSPEC tuple_hash
     {
         using MyTuple = std::tuple<Types...>;
         using TypeN   = typename std::tuple_element<N, MyTuple>::type;
@@ -201,7 +203,7 @@ namespace rocRoller
     };
 
     template <class... Types>
-    struct tuple_hash<0, Types...>
+    struct ROCROLLER_DECLSPEC tuple_hash<0, Types...>
     {
         using MyTuple = std::tuple<Types...>;
         using Type0   = typename std::tuple_element<0, MyTuple>::type;
@@ -225,7 +227,7 @@ namespace rocRoller
 namespace std
 {
     template <class... Types>
-    struct hash<tuple<Types...>>
+    struct ROCROLLER_DECLSPEC hash<tuple<Types...>>
     {
         inline size_t operator()(tuple<Types...> const& tup) const
         {

--- a/lib/include/rocRoller/Utilities/Component.hpp
+++ b/lib/include/rocRoller/Utilities/Component.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <functional>
 #include <iostream>
@@ -47,10 +49,10 @@ namespace rocRoller
         };
 
         /**
-         * @brief A `ComponentBase` is a base class for a category of components.
+         * @brief A `ComponentBase` is a base class ROCROLLER_DECLSPEC for a category of components.
          *
          *  - It defines the interface for accessing the implementations.
-         *  - All subclasses should provide interchangeable functionality.
+         *  - All subclass ROCROLLER_DECLSPECes should provide interchangeable functionality.
          *
          */
         template <typename T>
@@ -75,19 +77,19 @@ namespace rocRoller
         /**
          * A function to match whether a given component is appropriate for the situation.
          *
-         * Only one subclass should match any given situation.
+         * Only one subclass ROCROLLER_DECLSPEC should match any given situation.
          */
         template <ComponentBase Base>
         using Matcher = std::function<bool(typename Base::Argument)>;
 
         /**
-         * A factory function to create an instance of a particular subclass.
+         * A factory function to create an instance of a particular subclass ROCROLLER_DECLSPEC.
          */
         template <ComponentBase Base>
         using Builder = std::function<std::shared_ptr<Base>(typename Base::Argument)>;
 
         /**
-         * A concrete subclass which fulfils the required functionality in a subset of situations.
+         * A concrete subclass ROCROLLER_DECLSPEC which fulfils the required functionality in a subset of situations.
          */
         template <typename T>
         concept Component = requires(T a)
@@ -118,7 +120,7 @@ namespace rocRoller
         };
 
         /**
-         * @brief Returns an object of the appropriate subclass of `Base`, based on `ctx`.
+         * @brief Returns an object of the appropriate subclass ROCROLLER_DECLSPEC of `Base`, based on `ctx`.
          * May be the same object from one call to the next.
          */
         template <ComponentBase Base>
@@ -140,7 +142,7 @@ namespace rocRoller
         // clang-format on
 
         /**
-         * @brief Returns a new instance object of the appropriate subclass of `Base`, based
+         * @brief Returns a new instance object of the appropriate subclass ROCROLLER_DECLSPEC of `Base`, based
          * on `ctx`.
          */
         template <ComponentBase Base>
@@ -184,7 +186,7 @@ namespace rocRoller
             = rocRoller::Component::RegisterComponentImpl<component<types>>(); \
     }
 
-        class ComponentFactoryBase
+        class ROCROLLER_DECLSPEC ComponentFactoryBase
         {
         public:
             static void ClearAllCaches();
@@ -198,12 +200,12 @@ namespace rocRoller
         };
 
         template <ComponentBase Base>
-        class ComponentFactory : public ComponentFactoryBase
+        class ROCROLLER_DECLSPEC ComponentFactory : public ComponentFactoryBase
         {
         public:
             using Argument = typename Base::Argument;
 
-            struct Entry
+            struct ROCROLLER_DECLSPEC Entry
             {
                 std::string   name;
                 Matcher<Base> matcher;
@@ -236,7 +238,7 @@ namespace rocRoller
             std::vector<Entry> m_entries;
 
             /**
-             * Finds an entry among the registered entries (classes).  This is the fallback for if there
+             * Finds an entry among the registered entries (class ROCROLLER_DECLSPECes).  This is the fallback for if there
              * is no entry in the cache.
              */
             template <typename T, bool Debug = false>

--- a/lib/include/rocRoller/Utilities/EnumBitset.hpp
+++ b/lib/include/rocRoller/Utilities/EnumBitset.hpp
@@ -25,6 +25,8 @@
  *******************************************************************************/
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <bitset>
 
 #include <rocRoller/Utilities/Concepts.hpp>
@@ -32,7 +34,7 @@
 namespace rocRoller
 {
     /**
-     * Bitset which uses an enum (class) as an indexer. Has the interface of std::bitset, and can be
+     * Bitset which uses an enum (class ROCROLLER_DECLSPEC) as an indexer. Has the interface of std::bitset, and can be
      * indexed by the enum.
      *
      * All new interfaces are constexpr so it can be used in concepts and to limit template instantiation.
@@ -42,7 +44,7 @@ namespace rocRoller
      * - Count must be <= 64.
      */
     template <CCountedEnum Enum>
-    class EnumBitset : public std::bitset<static_cast<size_t>(Enum::Count)>
+    class ROCROLLER_DECLSPEC EnumBitset : public std::bitset<static_cast<size_t>(Enum::Count)>
     {
     public:
         static constexpr size_t Size = static_cast<size_t>(Enum::Count);
@@ -69,10 +71,10 @@ namespace rocRoller
     };
 
     template <CCountedEnum Enum>
-    std::string toString(EnumBitset<Enum> const& bs);
+    ROCROLLER_DECLSPEC std::string toString(EnumBitset<Enum> const& bs);
 
     template <CCountedEnum Enum>
-    std::ostream& operator<<(std::ostream& stream, EnumBitset<Enum> const& bs);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream& stream, EnumBitset<Enum> const& bs);
 }
 
 #include <rocRoller/Utilities/EnumBitset_impl.hpp>

--- a/lib/include/rocRoller/Utilities/Error.hpp
+++ b/lib/include/rocRoller/Utilities/Error.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <concepts>
 #include <source_location>
 #include <stdexcept>
@@ -39,7 +41,7 @@
 
 namespace rocRoller
 {
-    struct Error : public std::runtime_error
+    struct ROCROLLER_DECLSPEC Error : public std::runtime_error
     {
         using std::runtime_error::runtime_error;
 
@@ -56,23 +58,23 @@ namespace rocRoller
         std::string m_annotatedMessage;
     };
 
-    struct FatalError : public Error
+    struct ROCROLLER_DECLSPEC FatalError : public Error
     {
         using Error::Error;
     };
 
-    struct RecoverableError : public Error
+    struct ROCROLLER_DECLSPEC RecoverableError : public Error
     {
         using Error::Error;
     };
 
     template <class T_Exception, typename... Ts>
-    [[noreturn]] void Throw(Ts const&...);
+    [[noreturn]] ROCROLLER_DECLSPEC void Throw(Ts const&...);
 
     /**
      * Initiates a segfault.  This can be useful for debugging purposes.
      */
-    [[noreturn]] void Crash();
+    [[noreturn]] ROCROLLER_DECLSPEC void Crash();
 
     int* GetNullPointer();
 

--- a/lib/include/rocRoller/Utilities/Error_fwd.hpp
+++ b/lib/include/rocRoller/Utilities/Error_fwd.hpp
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
-    class Error;
+    class ROCROLLER_DECLSPEC Error;
 
-    class FatalError;
-    class RecoverableError;
+    class ROCROLLER_DECLSPEC FatalError;
+    class ROCROLLER_DECLSPEC RecoverableError;
 }

--- a/lib/include/rocRoller/Utilities/Error_impl.hpp
+++ b/lib/include/rocRoller/Utilities/Error_impl.hpp
@@ -38,7 +38,7 @@ namespace rocRoller
     }
 
     template <typename T_Exception, typename... Ts>
-    [[noreturn]] void Throw(Ts const&... message)
+    inline void Throw(Ts const&... message)
     {
         bool var = Error::BreakOnThrow();
         if(var)

--- a/lib/include/rocRoller/Utilities/Generator.hpp
+++ b/lib/include/rocRoller/Utilities/Generator.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 /**
  * Compiler-specific tricks to get coroutines working
  *
@@ -90,8 +92,8 @@ namespace rocRoller
         Done,
         Count
     };
-    std::string   toString(GeneratorState s);
-    std::ostream& operator<<(std::ostream&, GeneratorState const&);
+    ROCROLLER_DECLSPEC std::string toString(GeneratorState s);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, GeneratorState const&);
 
     /**
      * Range/ConcreteRange wraps a collection object behind a virtual interface,
@@ -99,7 +101,7 @@ namespace rocRoller
      * and provide access to its items.
      */
     template <typename T>
-    struct Range
+    struct ROCROLLER_DECLSPEC Range
     {
         virtual ~Range() = default;
 
@@ -110,7 +112,7 @@ namespace rocRoller
     };
 
     template <typename T, CInputRangeOf<T> TheRange>
-    struct ConcreteRange : public Range<T>
+    struct ROCROLLER_DECLSPEC ConcreteRange : public Range<T>
     {
         template <std::convertible_to<TheRange> ARange>
         explicit ConcreteRange(ARange&& r);
@@ -331,7 +333,7 @@ namespace rocRoller
      *
      */
     template <std::movable T>
-    class Generator
+    class ROCROLLER_DECLSPEC Generator
     {
     public:
         /**
@@ -343,7 +345,7 @@ namespace rocRoller
          * state of whether we currently have a value or not, and whether we
          * currently have a range or not.
          */
-        class promise_type
+        class ROCROLLER_DECLSPEC promise_type
         {
         public:
             /****
@@ -405,7 +407,7 @@ namespace rocRoller
          * `std::default_sentinel_t`, not `Iterator`.  The
          * `std::common_iterator<>` adaptor provides that functionality.
          */
-        class Iterator
+        class ROCROLLER_DECLSPEC Iterator
         {
         public:
             // Required for STL iterator adaptors.  Not actually required to provide the - operator though.

--- a/lib/include/rocRoller/Utilities/HIPTimer.hpp
+++ b/lib/include/rocRoller/Utilities/HIPTimer.hpp
@@ -32,6 +32,8 @@
 
 #ifdef ROCROLLER_USE_HIP
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <chrono>
 #include <map>
 #include <memory>
@@ -49,7 +51,7 @@
 
 namespace rocRoller
 {
-    class HIPTimer : public Timer
+    class ROCROLLER_DECLSPEC HIPTimer : public Timer
     {
     public:
         HIPTimer() = delete;

--- a/lib/include/rocRoller/Utilities/LazySingleton.hpp
+++ b/lib/include/rocRoller/Utilities/LazySingleton.hpp
@@ -26,12 +26,14 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <memory>
 
 namespace rocRoller
 {
     template <typename Class>
-    class LazySingleton
+    class ROCROLLER_DECLSPEC LazySingleton
     {
     public:
         static std::shared_ptr<Class> getInstance()

--- a/lib/include/rocRoller/Utilities/Logging.hpp
+++ b/lib/include/rocRoller/Utilities/Logging.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 // Only need the forward declaration of LogLevel
 #include <rocRoller/Utilities/Settings_fwd.hpp>
 
@@ -39,7 +41,7 @@ namespace rocRoller
     namespace Log
     {
 
-        class logger
+        class ROCROLLER_DECLSPEC logger
         {
         public:
             void log(LogLevel level, const std::string& str);
@@ -78,7 +80,7 @@ namespace rocRoller
         };
 
         using LoggerPtr = std::shared_ptr<logger>;
-        LoggerPtr getLogger();
+        ROCROLLER_DECLSPEC LoggerPtr getLogger();
 
         inline void log(LogLevel level, const std::string& str)
         {

--- a/lib/include/rocRoller/Utilities/Random.hpp
+++ b/lib/include/rocRoller/Utilities/Random.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <cstdlib>
 #include <random>
 #include <vector>
@@ -48,7 +50,7 @@ namespace rocRoller
      * A seed may be set programmatically (at any time) by calling
      * seed().
      */
-    class RandomGenerator
+    class ROCROLLER_DECLSPEC RandomGenerator
     {
     public:
         explicit RandomGenerator(int seedNumber);

--- a/lib/include/rocRoller/Utilities/Random_fwd.hpp
+++ b/lib/include/rocRoller/Utilities/Random_fwd.hpp
@@ -30,7 +30,9 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 namespace rocRoller
 {
-    class RandomGenerator;
+    class ROCROLLER_DECLSPEC RandomGenerator;
 }

--- a/lib/include/rocRoller/Utilities/Settings.hpp
+++ b/lib/include/rocRoller/Utilities/Settings.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <any>
 #include <bitset>
 #include <functional>
@@ -50,7 +52,7 @@ namespace rocRoller
      *
      * Keeps track of its instances, so do not create temporaries.
     */
-    struct SettingsOptionBase
+    struct ROCROLLER_DECLSPEC SettingsOptionBase
     {
         std::string name;
         std::string description;
@@ -76,7 +78,7 @@ namespace rocRoller
      * @tparam T type of underlying option.
      */
     template <typename T, bool LazyValue = false>
-    struct SettingsOption : public SettingsOptionBase
+    struct ROCROLLER_DECLSPEC SettingsOption : public SettingsOptionBase
     {
         using Type = T;
         using DefaultValueType =
@@ -97,11 +99,11 @@ namespace rocRoller
         int                     getBitIndex() const;
     };
 
-    std::string   toString(LogLevel level);
-    std::ostream& operator<<(std::ostream&, LogLevel const&);
+    ROCROLLER_DECLSPEC std::string toString(LogLevel level);
+    ROCROLLER_DECLSPEC std::ostream& operator<<(std::ostream&, LogLevel const&);
 
     /**
-     * @brief Settings class is derived from lazy singleton class and handles options
+     * @brief Settings class is derived from lazy singleton class  and handles options
      * that are defined through environment variables or developer defined options.
      *
      * Getting a value requires a call to get(SettingsOption opt). When get() is called,
@@ -112,7 +114,7 @@ namespace rocRoller
      *
      * A call to set(SettingsOption opt) sets (or overwrites) the corresponding value in m_values.
      */
-    class Settings : public LazySingleton<Settings>
+    class ROCROLLER_DECLSPEC Settings : public LazySingleton<Settings>
     {
     public:
         using bitFieldType = std::bitset<32>;
@@ -284,6 +286,8 @@ namespace rocRoller
         std::map<std::string, std::any> m_values;
         std::vector<std::string>        m_setBitOptions;
     };
+
+    ROCROLLER_DECLSPEC F8Mode getDefaultF8ModeForCurrentHipDevice();
 }
 
 #include <rocRoller/Utilities/Settings_impl.hpp>

--- a/lib/include/rocRoller/Utilities/Settings_fwd.hpp
+++ b/lib/include/rocRoller/Utilities/Settings_fwd.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 
 namespace rocRoller
@@ -53,9 +55,7 @@ namespace rocRoller
 
     std::string toString(F8Mode);
 
-    F8Mode getDefaultF8ModeForCurrentHipDevice();
+    ROCROLLER_DECLSPEC F8Mode getDefaultF8ModeForCurrentHipDevice();
 
-    const char* getDefaultArchitectureFilePath();
-
-    class Settings;
+    class ROCROLLER_DECLSPEC Settings;
 }

--- a/lib/include/rocRoller/Utilities/Timer.hpp
+++ b/lib/include/rocRoller/Utilities/Timer.hpp
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <atomic>
 #include <chrono>
 #include <map>
@@ -55,7 +57,7 @@ namespace rocRoller
      * Elapsed times are accumulated (atomically) by name.  Times are
      * accumulated by the rocRoller::Timer class below.
      */
-    class TimerPool
+    class ROCROLLER_DECLSPEC TimerPool
     {
     public:
         TimerPool(TimerPool const&) = delete;
@@ -109,7 +111,7 @@ namespace rocRoller
      * When a timer is stopped (via toc()) the elapsed time is added
      * to the TimerPool.
      */
-    class Timer
+    class ROCROLLER_DECLSPEC Timer
     {
     public:
         Timer() = delete;

--- a/lib/include/rocRoller/Utilities/Utils.hpp
+++ b/lib/include/rocRoller/Utilities/Utils.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -56,19 +58,19 @@ namespace rocRoller
      */
 
     template <typename T>
-    constexpr T CeilDivide(T num, T den)
+    ROCROLLER_DECLSPEC constexpr T CeilDivide(T num, T den)
     {
         return (num + (den - 1)) / den;
     }
 
     template <typename T>
-    constexpr T RoundUpToMultiple(T val, T den)
+    ROCROLLER_DECLSPEC constexpr T RoundUpToMultiple(T val, T den)
     {
         return CeilDivide(val, den) * den;
     }
 
     template <typename T, typename = typename std::enable_if<std::is_integral<T>::value>>
-    constexpr T IsPrime(T val)
+    ROCROLLER_DECLSPEC constexpr T IsPrime(T val)
     {
         if(val < 2)
             return false;
@@ -84,7 +86,7 @@ namespace rocRoller
     }
 
     template <typename T, typename = typename std::enable_if<std::is_integral<T>::value>>
-    constexpr T NextPrime(T val)
+    ROCROLLER_DECLSPEC constexpr T NextPrime(T val)
     {
         if(val < 2)
             return 2;
@@ -94,7 +96,7 @@ namespace rocRoller
     }
 
     template <typename T>
-    std::variant<T> singleVariant(T value)
+    ROCROLLER_DECLSPEC std::variant<T> singleVariant(T value)
     {
         return std::variant<T>(std::move(value));
     }
@@ -108,7 +110,7 @@ namespace rocRoller
      * - No two sets in return value have any common elements.
      * - mergeSets(mergeSets(x)) == mergeSets(x) for any x.
      */
-    std::vector<std::set<int>> mergeSets(std::vector<std::set<int>> sets);
+    ROCROLLER_DECLSPEC std::vector<std::set<int>> mergeSets(std::vector<std::set<int>> sets);
 
     inline std::string toString(int x)
     {
@@ -123,7 +125,7 @@ namespace rocRoller
     }
 
     template <typename Container, typename Joiner>
-    void streamJoin(std::ostream& stream, Container const& c, Joiner const& j)
+    ROCROLLER_DECLSPEC void streamJoin(std::ostream& stream, Container const& c, Joiner const& j)
     {
         bool first = true;
         for(auto const& item : c)
@@ -235,7 +237,7 @@ namespace rocRoller
         return concatenate(vals...);
     }
 
-    class StreamRead
+    class ROCROLLER_DECLSPEC StreamRead
     {
     public:
         explicit StreamRead(std::string const& value, bool except = true);
@@ -256,7 +258,7 @@ namespace rocRoller
         return stream;
     }
 
-    struct BitFieldGenerator
+    struct ROCROLLER_DECLSPEC BitFieldGenerator
     {
         constexpr static uint32_t maxBitFieldWidth = 32;
 
@@ -294,20 +296,20 @@ namespace rocRoller
     };
 
     template <std::integral T>
-    Generator<T> iota(T begin, T end, T inc)
+    ROCROLLER_DECLSPEC Generator<T> iota(T begin, T end, T inc)
     {
         for(; begin < end; begin += inc)
             co_yield begin;
     }
 
     template <std::integral T>
-    Generator<T> iota(T begin, T end)
+    ROCROLLER_DECLSPEC Generator<T> iota(T begin, T end)
     {
         co_yield iota<T>(begin, end, 1);
     }
 
     template <std::integral T>
-    Generator<T> iota(T begin)
+    ROCROLLER_DECLSPEC Generator<T> iota(T begin)
     {
         for(;; ++begin)
             co_yield begin;
@@ -359,7 +361,7 @@ namespace rocRoller
 
     // helper for visitor
     template <class... Ts>
-    struct overloaded : Ts...
+    struct ROCROLLER_DECLSPEC overloaded : Ts...
     {
         // cppcheck-suppress syntaxError
         using Ts::operator()...;
@@ -373,20 +375,20 @@ namespace rocRoller
      * Converts a string value to an enum by comparing against each toString conversion.
      */
     template <CCountedEnum T>
-    T fromString(std::string const& str);
+    ROCROLLER_DECLSPEC T fromString(std::string const& str);
 
     template <CHasName T>
-    requires(std::default_initializable<T>) std::string name()
+    requires(std::default_initializable<T>) ROCROLLER_DECLSPEC std::string name()
     {
         T obj;
         return name(obj);
     }
 
-    std::string escapeSymbolName(std::string name);
+    ROCROLLER_DECLSPEC std::string escapeSymbolName(std::string name);
 
-    std::vector<char> readFile(std::string const&);
+    ROCROLLER_DECLSPEC std::vector<char> readFile(std::string const&);
 
-    std::string readMetaDataFromCodeObject(std::string const& fileName);
+    ROCROLLER_DECLSPEC std::string readMetaDataFromCodeObject(std::string const& fileName);
 
     /**
      * @}

--- a/lib/include/rocRoller/Utilities/Version.hpp
+++ b/lib/include/rocRoller/Utilities/Version.hpp
@@ -26,12 +26,14 @@
 
 #pragma once
 
+#include <rocRoller/rocRoller.hpp>
+
 #include <string>
 
 namespace rocRoller
 {
     namespace Version
     {
-        std::string Git();
+        ROCROLLER_DECLSPEC std::string Git();
     }
 }

--- a/lib/include/rocRoller/rocRoller.hpp
+++ b/lib/include/rocRoller/rocRoller.hpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2024-2025 AMD ROCm(TM) Software
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#ifdef _WIN32
+#ifdef _EXPORTING
+#define ROCROLLER_DECLSPEC __declspec(dllexport)
+#else
+#define ROCROLLER_DECLSPEC __declspec(dllimport)
+#endif
+#else
+#define ROCROLLER_DECLSPEC __attribute__((visibility("default")))
+#endif

--- a/lib/source/CodeGen/LoadStoreTileGenerator.cpp
+++ b/lib/source/CodeGen/LoadStoreTileGenerator.cpp
@@ -45,6 +45,7 @@
 #include <rocRoller/KernelGraph/Utils.hpp>
 #include <rocRoller/Scheduling/Scheduler.hpp>
 #include <rocRoller/Utilities/Error.hpp>
+#include <rocRoller/Utilities/Utils.hpp>
 
 namespace rocRoller
 {

--- a/lib/source/CodeGen/MemoryInstructions.cpp
+++ b/lib/source/CodeGen/MemoryInstructions.cpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #include <rocRoller/CodeGen/MemoryInstructions.hpp>
+#include <rocRoller/CodeGen/Utils.hpp>
 #include <rocRoller/InstructionValues/Register.hpp>
 
 namespace rocRoller

--- a/lib/source/ExpressionTransformations/FastMultiplication.cpp
+++ b/lib/source/ExpressionTransformations/FastMultiplication.cpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #include <rocRoller/Expression.hpp>
+#include <rocRoller/ExpressionTransformations.hpp>
 
 #include <bit>
 

--- a/lib/source/ExpressionTransformations/FuseTernary.cpp
+++ b/lib/source/ExpressionTransformations/FuseTernary.cpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #include <rocRoller/Expression.hpp>
+#include <rocRoller/ExpressionTransformations.hpp>
 
 template <typename T>
 constexpr auto cast_to_unsigned(T val)

--- a/lib/source/ExpressionTransformations/Identity.cpp
+++ b/lib/source/ExpressionTransformations/Identity.cpp
@@ -24,6 +24,7 @@
  *
  *******************************************************************************/
 
+#include <rocRoller/ExpressionTransformations.hpp>
 #include <rocRoller/Expression_fwd.hpp>
 
 namespace rocRoller

--- a/lib/source/ExpressionTransformations/LowerExponential.cpp
+++ b/lib/source/ExpressionTransformations/LowerExponential.cpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #include <rocRoller/Expression.hpp>
+#include <rocRoller/ExpressionTransformations.hpp>
 
 namespace rocRoller
 {

--- a/lib/source/ExpressionTransformations/LowerPRNG.cpp
+++ b/lib/source/ExpressionTransformations/LowerPRNG.cpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #include <rocRoller/Expression.hpp>
+#include <rocRoller/ExpressionTransformations.hpp>
 
 namespace rocRoller
 {

--- a/lib/source/ExpressionTransformations/RestoreCommandArguments.cpp
+++ b/lib/source/ExpressionTransformations/RestoreCommandArguments.cpp
@@ -26,6 +26,7 @@
 
 #include <rocRoller/AssemblyKernel.hpp>
 #include <rocRoller/Expression.hpp>
+#include <rocRoller/ExpressionTransformations.hpp>
 #include <rocRoller/Utilities/Error.hpp>
 
 namespace rocRoller

--- a/lib/source/ExpressionTransformations/Simplify.cpp
+++ b/lib/source/ExpressionTransformations/Simplify.cpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #include <rocRoller/Expression.hpp>
+#include <rocRoller/ExpressionTransformations.hpp>
 
 template <typename T>
 constexpr auto cast_to_unsigned(T val)

--- a/lib/source/KernelGraph/Transformations/CleanArguments.cpp
+++ b/lib/source/KernelGraph/Transformations/CleanArguments.cpp
@@ -35,6 +35,8 @@
 
 #include <rocRoller/Operations/Command.hpp>
 
+#include <rocRoller/KernelGraph/Utils.hpp>
+
 namespace rocRoller
 {
     namespace KernelGraph

--- a/lib/source/KernelGraph/Transformations/UnrollLoops.cpp
+++ b/lib/source/KernelGraph/Transformations/UnrollLoops.cpp
@@ -32,6 +32,7 @@
 #include <rocRoller/KernelGraph/Transforms/UnrollLoops.hpp>
 #include <rocRoller/KernelGraph/Utils.hpp>
 #include <rocRoller/KernelGraph/Visitors.hpp>
+
 namespace rocRoller
 {
     namespace KernelGraph

--- a/test/catch/SimpleTest.hpp
+++ b/test/catch/SimpleTest.hpp
@@ -33,7 +33,7 @@ class SimpleTest
 {
 public:
     SimpleTest() = default;
-    ~SimpleTest()
+    virtual ~SimpleTest()
     {
         rocRoller::Settings::reset();
         rocRoller::Component::ComponentFactoryBase::ClearAllCaches();

--- a/test/catch/SubDwordExpressionTest.cpp
+++ b/test/catch/SubDwordExpressionTest.cpp
@@ -44,35 +44,35 @@ namespace SubDwordExpressionTest
         SECTION("cannot get bitfield from a literal")
         {
             auto literal = Register::Value::Literal(42);
-            CHECK_THROWS(literal->bitfield(8, 8));
+            CHECK_THROWS_AS(literal->bitfield(8, 8), FatalError);
         }
 
         SECTION("bitOffset cannot be greater than the number of bits in a Value")
         {
             auto r = std::make_shared<Register::Value>(
                 context.get(), Register::Type::Vector, DataType::UInt32, 1);
-            CHECK_THROWS(r->bitfield(32, 8));
+            CHECK_THROWS_AS(r->bitfield(32, 8), FatalError);
         }
 
         SECTION("bitwidth cannot be zero")
         {
             auto r = std::make_shared<Register::Value>(
                 context.get(), Register::Type::Vector, DataType::UInt32, 1);
-            CHECK_THROWS(r->bitfield(8, 0));
+            CHECK_THROWS_AS(r->bitfield(8, 0), FatalError);
         }
 
         SECTION("bitwidth cannot be greater than the number of bits in a register")
         {
             auto r = std::make_shared<Register::Value>(
                 context.get(), Register::Type::Vector, DataType::UInt32, 1);
-            CHECK_THROWS(r->bitfield(8, 32));
+            CHECK_THROWS_AS(r->bitfield(8, 32), FatalError);
         }
 
         SECTION("indices must refer to adjacent elements")
         {
             auto r = std::make_shared<Register::Value>(
                 context.get(), Register::Type::Vector, DataType::UInt8x4, 1);
-            CHECK_THROWS(r->segment({0, 2}));
+            CHECK_THROWS_AS(r->segment({0, 2}), FatalError);
         }
 
         SECTION("generate from expression with bitfields")

--- a/test/unit/MatrixMultiplyTest.cpp
+++ b/test/unit/MatrixMultiplyTest.cpp
@@ -44,6 +44,7 @@
 #include <rocRoller/TensorDescriptor.hpp>
 #include <rocRoller/Utilities/Error.hpp>
 #include <rocRoller/Utilities/Timer.hpp>
+#include <rocRoller/Utilities/Utils.hpp>
 
 #include "GPUContextFixture.hpp"
 #include "SourceMatcher.hpp"


### PR DESCRIPTION
*Original author: @awhittle*

# PR overview

For HipBLASLt integration and general library health.  This PR can be read commit by commit (the ones adding the declspecs can probably be skimmed over).

This PR:
- Hides library symbols by default
- Adds the `ROCROLLER_DECLSPEC` macro
- Adds the `ROCROLLER_DECLSPEC` macro everywhere it is needed
- Fixes a unit test that messes with the settings and environment variables

Here's a primer:
- `ROCROLLER_DECLSPEC` allows library symbols to be visible
- When adding a new function, class, or struct, add `ROCROLLER_DECLSPEC` to the function declaration in the .hpp file if the following conditions are met:
    - The function, class, or struct should be used outside of the library, like in a test or an application
    - The function, class, or struct is is defined a .cpp file
        - DO NOT add it to `inline` functions. The user will have the function definition when including the .hpp.
- `ROCROLLER_DECLSPEC` should not appear in _impl.hpp or .cpp files
- You'll see LD errors if you didn't export the symbol correctly

## Testing

Tests should pass as before.

NB: Run `nm -CD librocroller.so` to see the the symbols exposed.

# Commit message

Add the `ROCROLLER_DECLSPEC` macro

Hides library symbols by default
Fix the settings unit test