### PR TITLE
LWP100-1638 part 1: Add AddLDSPadding transform.

### DIFF
--- a/client/gemm.cpp
+++ b/client/gemm.cpp
@@ -177,6 +177,8 @@ struct rocRoller::Serialization::MappingTraits<Client::GEMMClient::SolutionParam
         iot::mapRequired(io, "unroll_y", params.unrollY);
         iot::mapRequired(io, "loadLDS_A", params.loadLDSA);
         iot::mapRequired(io, "loadLDS_B", params.loadLDSB);
+        iot::mapRequired(io, "padLDS_A", params.padLDSA);
+        iot::mapRequired(io, "padLDS_B", params.padLDSB);
         iot::mapRequired(io, "storeLDS_D", params.storeLDSD);
         iot::mapRequired(io, "direct2LDS_A", params.direct2LDSA);
         iot::mapRequired(io, "direct2LDS_B", params.direct2LDSB);
@@ -1177,6 +1179,9 @@ int main(int argc, const char* argv[])
         .loadLDSB  = true,
         .storeLDSD = true,
 
+        .padLDSA = -1,
+        .padLDSB = -1,
+
         .direct2LDSA = false,
         .direct2LDSB = false,
 
@@ -1356,6 +1361,12 @@ int main(int argc, const char* argv[])
     app.add_option("--unroll_y", solution.unrollY, "Unroll size in Y.");
     app.add_flag("--loadLDS_A", solution.loadLDSA, "Use LDS when loading A.");
     app.add_flag("--loadLDS_B", solution.loadLDSB, "Use LDS when loading B.");
+    app.add_option("--padLDS_A",
+                   solution.padLDSA,
+                   "Element padding for A LDS buffer: -1 means automatic.  Default is -1.");
+    app.add_option("--padLDS_B",
+                   solution.padLDSB,
+                   "Element padding for B LDS buffer: -1 means automatic.  Default is -1.");
     app.add_flag("--storeLDS_D", solution.storeLDSD, "Use LDS when storing D.");
     app.add_flag("--direct2LDS_A", solution.direct2LDSA, "Use direct-to-LDS when loading A.");
     app.add_flag("--direct2LDS_B", solution.direct2LDSB, "Use direct-to-LDS when loading B.");

--- a/client/include/DataParallelGEMMSolution.hpp
+++ b/client/include/DataParallelGEMMSolution.hpp
@@ -362,6 +362,9 @@ namespace rocRoller
                     else if(solutionParams.loadLDSB)
                         memoryTypeB = MemoryType::LDS;
 
+		    params->padLDS[LayoutType::MATRIX_A] = solutionParams.padLDSA;
+		    params->padLDS[LayoutType::MATRIX_B] = solutionParams.padLDSB;
+
                     auto macTileA = KernelGraph::CoordinateGraph::MacroTile(
                         {solutionParams.macM, solutionParams.macK},
                         LayoutType::MATRIX_A,

--- a/client/include/GEMMParameters.hpp
+++ b/client/include/GEMMParameters.hpp
@@ -148,6 +148,9 @@ namespace rocRoller
                 bool loadLDSB  = true;
                 bool storeLDSD = true;
 
+                int padLDSA = -1;
+                int padLDSB = -1;
+
                 bool direct2LDSA = false;
                 bool direct2LDSB = false;
 

--- a/client/test_gemm_client.py
+++ b/client/test_gemm_client.py
@@ -248,6 +248,8 @@ unroll_x: 0
 unroll_y: 0
 loadLDS_A: true
 loadLDS_B: true
+padLDS_A: -1
+padLDS_B: -1
 storeLDS_D: true
 direct2LDS_A: false
 direct2LDS_B: false
@@ -302,6 +304,8 @@ unroll_x: 0
 unroll_y: 0
 loadLDS_A: true
 loadLDS_B: true
+padLDS_A: -1
+padLDS_B: -1
 storeLDS_D: true
 direct2LDS_A: false
 direct2LDS_B: false
@@ -355,6 +359,8 @@ unroll_x: 0
 unroll_y: 0
 loadLDS_A: true
 loadLDS_B: true
+padLDS_A: -1
+padLDS_B: -1
 storeLDS_D: true
 direct2LDS_A: false
 direct2LDS_B: false

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -184,6 +184,7 @@ set(rocroller_src
     source/KernelGraph/Transformations/AddDirect2LDS.cpp
     source/KernelGraph/Transformations/AddF6LDSPadding.cpp
     source/KernelGraph/Transformations/AddLDS.cpp
+    source/KernelGraph/Transformations/AddLDSPadding.cpp
     source/KernelGraph/Transformations/AddPRNG.cpp
     source/KernelGraph/Transformations/AddPrefetch.cpp
     source/KernelGraph/Transformations/AddStreamK.cpp

--- a/lib/include/rocRoller/CommandSolution.hpp
+++ b/lib/include/rocRoller/CommandSolution.hpp
@@ -144,6 +144,19 @@ namespace rocRoller
         std::optional<std::pair<int, Expression::ExpressionPtr>> workgroupMapping  = {};
         std::optional<int>                                       workgroupRemapXCC = {};
 
+        /**
+	 * @brief Padding for LDS.
+	 *
+	 * Map from LayoutType to number of LDS padding elements (not bytes!).
+	 *
+	 * A value of -1 means rocRoller will compute a padding value
+	 * automatically.  This is the default behaviour for MATRIX_A
+	 * and MATRIX_B layouts.  See `computeDefaultLDSPaddingElements()`.
+	 *
+	 * A value of 0 means no padding.
+	 */
+        std::map<LayoutType, int> padLDS = {{LayoutType::MATRIX_A, -1}, {LayoutType::MATRIX_B, -1}};
+
     private:
         std::map<Operations::OperationTag, KernelGraph::CoordinateGraph::Dimension> m_dimInfo;
         std::optional<std::array<unsigned int, 3>>                                  m_workgroupSize;

--- a/lib/include/rocRoller/KernelGraph/Transforms/AddLDSPadding.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/AddLDSPadding.hpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2025 AMD ROCm(TM) Software
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+#include <rocRoller/Context_fwd.hpp>
+#include <rocRoller/KernelGraph/Transforms/GraphTransform.hpp>
+
+namespace rocRoller
+{
+    namespace KernelGraph
+    {
+
+        /**
+         * @brief Rewrite KernelGraph to add padding to LDS buffers.
+         * @ingroup Transformations
+         */
+        class AddLDSPadding : public GraphTransform
+        {
+        public:
+            AddLDSPadding(CommandParametersPtr params)
+                : m_params(params)
+            {
+            }
+
+            KernelGraph apply(KernelGraph const& original) override;
+            std::string name() const override
+            {
+                return "AddLDSPadding";
+            }
+
+        private:
+            CommandParametersPtr m_params;
+        };
+    }
+}

--- a/lib/include/rocRoller/KernelGraph/Transforms/AddLDSPadding_detail.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/AddLDSPadding_detail.hpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2025 AMD ROCm(TM) Software
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+#include <rocRoller/KernelGraph/Transforms/AddLDSPadding.hpp>
+
+namespace rocRoller
+{
+    namespace KernelGraph
+    {
+        namespace AddLDSPaddingDetail
+        {
+            /**
+	     * @brief Information about LDS padding.
+	     *
+	     * Information about LDS padding that is being added to
+	     * the graph.
+	     */
+            struct LDSPaddingInfo
+            {
+                int              ldsTag;
+                int              upstreamEdge, downstreamEdge;
+                std::vector<int> upstreamTags;
+                std::vector<int> downstreamTags;
+                DataType         dataType;
+                LayoutType       layoutType;
+            };
+
+            /**
+	     * @brief Get the number of padding elements.
+	     */
+            uint computeDefaultLDSPaddingElements(KernelGraph const&    graph,
+                                                  LDSPaddingInfo const& info);
+        }
+    }
+}

--- a/lib/include/rocRoller/KernelGraph/Transforms/All.hpp
+++ b/lib/include/rocRoller/KernelGraph/Transforms/All.hpp
@@ -32,6 +32,7 @@
 #include <rocRoller/KernelGraph/Transforms/AddDirect2LDS.hpp>
 #include <rocRoller/KernelGraph/Transforms/AddF6LDSPadding.hpp>
 #include <rocRoller/KernelGraph/Transforms/AddLDS.hpp>
+#include <rocRoller/KernelGraph/Transforms/AddLDSPadding.hpp>
 #include <rocRoller/KernelGraph/Transforms/AddPRNG.hpp>
 #include <rocRoller/KernelGraph/Transforms/AddPrefetch.hpp>
 #include <rocRoller/KernelGraph/Transforms/AddStreamK.hpp>

--- a/lib/source/CodeGen/Arithmetic/Multiply.cpp
+++ b/lib/source/CodeGen/Arithmetic/Multiply.cpp
@@ -78,6 +78,9 @@ namespace rocRoller
         AssertFatal(lhs != nullptr);
         AssertFatal(rhs != nullptr);
 
+        // TODO Is this necessary?
+        if(rhs->regType() == Register::Type::Literal)
+            co_yield m_context->copier()->ensureType(rhs, rhs, Register::Type::Vector);
         co_yield_(Instruction("v_mul_lo_u32", {dest}, {lhs, rhs}, {}, ""));
     }
 

--- a/lib/source/CommandSolution.cpp
+++ b/lib/source/CommandSolution.cpp
@@ -346,6 +346,7 @@ namespace rocRoller
         transforms.push_back(
             std::make_shared<KernelGraph::LowerTensorContraction>(m_commandParameters, m_context));
         transforms.push_back(std::make_shared<KernelGraph::Simplify>());
+        transforms.push_back(std::make_shared<KernelGraph::AddLDSPadding>(m_commandParameters));
 
         // TODO: simplify the condition by making ConstantPropagation and
         // Streamk work simultaneously

--- a/lib/source/KernelGraph/Transformations/AddLDSPadding.cpp
+++ b/lib/source/KernelGraph/Transformations/AddLDSPadding.cpp
@@ -1,0 +1,332 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2024-2025 AMD ROCm(TM) Software
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+/**
+@class AddLDSPadding
+@brief Add element padding to LDS buffers.
+
+Padding LDS buffers is used to reduce the number of LDS bank
+conflicts.
+
+Padding is added to flat LDS buffers.  For each `LDS` node, upstream
+`Flatten` edges are transformed to `Join` edges, and downstream
+`Tile` edges are transformed to `Split` edges.
+
+Recall that `Join` and `Split` edges honour the `stride` attribute of
+upstream/downstream nodes.  Padding is accomplished by updating the
+`stride` attributes of the upstream/downsteam nodes.
+
+In particular, the slow strides are set to the fast size plus a
+padding value, and the fast strides are set to 1.
+
+For example:
+
+    MacroTileIndex                  MacroTileIndex
+       size=256                       size=128
+                 \                  /
+                  ------------------
+                          |
+                       Flatten
+                          |
+                         LDS
+                     size=32,768
+                          |
+                        Tile
+                          |
+                  ------------------
+                 /                  \
+    MacroTileIndex                 MacroTileIndex
+       size=256                       size=128
+
+will be transformed to:
+
+    MacroTileIndex                  MacroTileIndex
+       size=256                       size=128
+   stride=128+padding                 stride=1
+                 \                  /
+                  ------------------
+                          |
+                        Join
+                          |
+                         LDS
+              size=32,768 + 256*padding
+                          |
+                        Split
+                          |
+                  ------------------
+                 /                  \
+    MacroTileIndex                 MacroTileIndex
+       size=256                       size=128
+    stride=128+padding                stride=1
+
+
+Note that the size of the LDS allocation is computed in `getNumLDSElements()`.
+
+*/
+
+#include <rocRoller/CommandSolution.hpp>
+#include <rocRoller/Expression.hpp>
+#include <rocRoller/KernelGraph/KernelGraph.hpp>
+#include <rocRoller/KernelGraph/Transforms/AddLDSPadding.hpp>
+#include <rocRoller/KernelGraph/Transforms/AddLDSPadding_detail.hpp>
+#include <rocRoller/KernelGraph/Utils.hpp>
+
+namespace rocRoller
+{
+    namespace KernelGraph
+    {
+        using GD = Graph::Direction;
+
+        using namespace Expression;
+        using namespace ControlGraph;
+        using namespace CoordinateGraph;
+
+        namespace AddLDSPaddingDetail
+        {
+            uint computeDefaultLDSPaddingElements(KernelGraph const&    graph,
+                                                  LDSPaddingInfo const& info)
+            {
+                constexpr uint ldsBankWidthInBits = 32u;
+
+                auto dataTypeInfo = DataTypeInfo::Get(info.dataType);
+
+                if(dataTypeInfo.elementBits % 4 != 0)
+                    return 0u;
+
+                return ldsBankWidthInBits / dataTypeInfo.elementBits;
+            }
+        }
+
+        using namespace AddLDSPaddingDetail;
+
+        void
+            updateStrides(KernelGraph& graph, std::vector<int> const& tags, auto numPaddingElements)
+        {
+            AssertFatal(tags.size() == 2, ShowValue(tags));
+
+            auto slowerTag = tags[0];
+            auto fasterTag = tags[1];
+
+            auto slowerDim = graph.coordinates.getNode(slowerTag);
+            auto fasterDim = graph.coordinates.getNode(fasterTag);
+
+            // New slow stride is: size of the faster dimension plus padding
+            auto slowStride = getSize(fasterDim) + literal(numPaddingElements);
+            setStride(slowerDim, slowStride);
+            setStride(fasterDim, literal(1u));
+
+            graph.coordinates.setElement(slowerTag, slowerDim);
+            graph.coordinates.setElement(fasterTag, fasterDim);
+
+            Log::debug("KernelGraph::AddLDSPadding::updateStrides: slow {}, fast {}, "
+                       "numPaddingElements {}, new slow stride {}",
+                       slowerTag,
+                       fasterTag,
+                       numPaddingElements,
+                       toString(slowStride));
+        }
+
+        std::optional<std::pair<LayoutType, DataType>>
+            getLayoutTypeAndDataType(KernelGraph const& graph, int ldsTag)
+        {
+            namespace CT = rocRoller::KernelGraph::CoordinateGraph;
+
+            std::optional<LayoutType> layoutType;
+            std::optional<DataType>   dataType;
+
+            auto isDataFlow = [&](int tag) -> bool {
+                return graph.coordinates.get<CT::DataFlow>(tag).has_value();
+            };
+
+            auto target = ldsTag;
+            while(true)
+            {
+                if(!dataType)
+                {
+                    for(auto conn : graph.mapper.getCoordinateConnections(target))
+                        dataType = getVariableType(graph, conn.control).dataType;
+                }
+
+                auto edge = only(
+                    filter(isDataFlow, graph.coordinates.getNeighbours<GD::Upstream>(target)));
+                if(!edge)
+                    break;
+                target = only(graph.coordinates.getNeighbours<GD::Upstream>(*edge)).value();
+
+                if(!layoutType)
+                {
+                    auto maybeMacroTile = graph.coordinates.get<MacroTile>(target);
+                    if(maybeMacroTile)
+                        layoutType = maybeMacroTile->layoutType;
+                }
+            }
+
+            if(layoutType && dataType)
+                return std::pair<LayoutType, DataType>{layoutType.value(), dataType.value()};
+
+            return {};
+        }
+
+        /**
+         * @brief Add LDS padding transformer.
+         */
+        struct AddLDSPaddingVisitor
+        {
+            AddLDSPaddingVisitor(CommandParametersPtr params)
+                : m_params(std::move(params))
+            {
+            }
+
+            void stage(KernelGraph const&, int);
+            void commit(KernelGraph&);
+
+        private:
+            uint getLDSPaddingElements(KernelGraph const&, LDSPaddingInfo const&) const;
+
+            CommandParametersPtr          m_params;
+            std::map<int, LDSPaddingInfo> m_ldsTags;
+        };
+
+        /**
+	 * @brief Get the number of padding elements for a given LDS
+	 * node.
+	 *
+	 * If the padding is set to -1, this will compute a default
+	 * padding value.
+	 */
+        uint AddLDSPaddingVisitor::getLDSPaddingElements(KernelGraph const&    graph,
+                                                         LDSPaddingInfo const& info) const
+        {
+            if(m_params->padLDS.contains(info.layoutType))
+            {
+                auto padding = m_params->padLDS.at(info.layoutType);
+                if(padding < 0)
+                    return computeDefaultLDSPaddingElements(graph, info);
+                return static_cast<uint>(padding);
+            }
+            return 0u;
+        }
+
+        /**
+         * @brief Stage LDS nodes that are flattened/tiled.
+         */
+        void AddLDSPaddingVisitor::stage(KernelGraph const& graph, int ldsTag)
+        {
+            std::optional<int> flattenEdgeTag;
+            {
+                for(auto elem : graph.coordinates.getNeighbours<GD::Upstream>(ldsTag))
+                {
+                    auto maybeFlatten = graph.coordinates.get<Flatten>(elem);
+                    if(!maybeFlatten)
+                        continue;
+                    flattenEdgeTag = elem;
+                }
+            }
+            if(not flattenEdgeTag)
+                return;
+
+            std::optional<int> tileEdgeTag;
+            {
+                for(auto elem : graph.coordinates.getNeighbours<GD::Downstream>(ldsTag))
+                {
+                    auto maybeTile = graph.coordinates.get<Tile>(elem);
+                    if(!maybeTile)
+                        continue;
+                    tileEdgeTag = elem;
+                }
+            }
+            if(not tileEdgeTag)
+                return;
+
+            auto maybeLayoutTypeAndDataType = getLayoutTypeAndDataType(graph, ldsTag);
+            if(!maybeLayoutTypeAndDataType)
+            {
+                Log::debug("KernelGraph::AddLDSPadding: "
+                           "Could not determine layout type and data type for LDS tag {}",
+                           ldsTag);
+                return;
+            }
+
+            auto upstreamTags
+                = graph.coordinates.getNeighbours<GD::Upstream>(*flattenEdgeTag).to<std::vector>();
+            auto downstreamTags
+                = graph.coordinates.getNeighbours<GD::Downstream>(*tileEdgeTag).to<std::vector>();
+
+            m_ldsTags[ldsTag] = LDSPaddingInfo{ldsTag,
+                                               *flattenEdgeTag,
+                                               *tileEdgeTag,
+                                               upstreamTags,
+                                               downstreamTags,
+                                               maybeLayoutTypeAndDataType->second,
+                                               maybeLayoutTypeAndDataType->first};
+        }
+
+        /**
+         * @brief Commit LDS padding changes to the graph.
+         *
+         * This will change the upstream Flatten edge to a Join edge,
+         * and the downstream Tile edge to a Split edge.
+         */
+        void AddLDSPaddingVisitor::commit(KernelGraph& graph)
+        {
+            for(auto const& [ldsTag, info] : m_ldsTags)
+            {
+                uint paddingElements = getLDSPaddingElements(graph, info);
+
+                Log::debug("KernelGraph::AddLDSPadding: ldsTag {}, upstreamEdge {}, "
+                           "downstreamEdge {}, paddingElements {}",
+                           info.ldsTag,
+                           info.upstreamEdge,
+                           info.downstreamEdge,
+                           paddingElements);
+
+                if(paddingElements == 0)
+                    continue;
+
+                // Change upstream edge to Join
+                graph.coordinates.setElement(info.upstreamEdge, Join());
+
+                // Change downstream edge to Split
+                graph.coordinates.setElement(info.downstreamEdge, Split());
+
+                // Change upstream and downstream tags
+                updateStrides(graph, info.upstreamTags, paddingElements);
+                updateStrides(graph, info.downstreamTags, paddingElements);
+            }
+        }
+
+        KernelGraph AddLDSPadding::apply(KernelGraph const& original)
+        {
+            TIMER(t, "KernelGraph::AddLDSPadding");
+            auto graph   = original;
+            auto visitor = AddLDSPaddingVisitor(m_params);
+            for(auto ldsTag : graph.coordinates.getNodes<LDS>())
+                visitor.stage(graph, ldsTag);
+            visitor.commit(graph);
+            return graph;
+        }
+    }
+}

--- a/next-cmake/include/CMakeLists.txt
+++ b/next-cmake/include/CMakeLists.txt
@@ -208,6 +208,8 @@ target_sources(rocroller
         "${_CMAKE_CURRENT_SOURCE_DIR}/rocRoller/KernelGraph/Transforms/AddDirect2LDS.hpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/rocRoller/KernelGraph/Transforms/AddF6LDSPadding.hpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/rocRoller/KernelGraph/Transforms/AddLDS.hpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/rocRoller/KernelGraph/Transforms/AddLDSPadding.hpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/rocRoller/KernelGraph/Transforms/AddLDSPadding_detail.hpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/rocRoller/KernelGraph/Transforms/AddPRNG.hpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/rocRoller/KernelGraph/Transforms/AddPrefetch.hpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/rocRoller/KernelGraph/Transforms/AddPrefetch_detail.hpp"

--- a/next-cmake/src/KernelGraph/Transformations/CMakeLists.txt
+++ b/next-cmake/src/KernelGraph/Transformations/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(rocroller
         "${_CMAKE_CURRENT_SOURCE_DIR}/AddDirect2LDS.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/AddF6LDSPadding.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/AddLDS.cpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/AddLDSPadding.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/AddPRNG.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/AddPrefetch.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/AddStreamK.cpp"

--- a/next-cmake/test/catch/CMakeLists.txt
+++ b/next-cmake/test/catch/CMakeLists.txt
@@ -48,9 +48,8 @@ target_link_libraries(rocroller-tests-catch
 set(_CMAKE_CURRENT_SOURCE_DIR "${ROCROLLER_TEST_DIR}/catch")
 target_sources(rocroller-tests-catch
     PRIVATE
-        "${_CMAKE_CURRENT_SOURCE_DIR}/CustomAssertions.cpp"
-        "${_CMAKE_CURRENT_SOURCE_DIR}/TestKernels.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/AddDeallocateTest.cpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/AddLDSPaddingTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/AddPrefetchTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/AliasDataFlowTagsTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/AnnotateInstructionsTest.cpp"
@@ -61,6 +60,7 @@ target_sources(rocroller-tests-catch
         "${_CMAKE_CURRENT_SOURCE_DIR}/CommandTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/ConnectWorkgroupsTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/CustomAssertionTest.cpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/CustomAssertions.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/CustomAssertions.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/CustomMatcherTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/DataTypesTest.cpp"
@@ -92,11 +92,13 @@ target_sources(rocroller-tests-catch
         "${_CMAKE_CURRENT_SOURCE_DIR}/RegisterTagManagerTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/RegisterTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/ScalarExpressionTest.cpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/ScaleUtilsTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/SettingsTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/SubDwordExpressionTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/TernaryExpressionTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/TestContext.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/TestContextTest.cpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/TestKernels.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/TestKernels.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/TransposeLoadsTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/UnrollLoopsTest.cpp"
@@ -105,5 +107,4 @@ target_sources(rocroller-tests-catch
         "${_CMAKE_CURRENT_SOURCE_DIR}/WMMAObserverUnitTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/WidenAddrExprTo64bitTest.cpp"
         "${_CMAKE_CURRENT_SOURCE_DIR}/mxDataGeneratorTest.cpp"
-        "${_CMAKE_CURRENT_SOURCE_DIR}/ScaleUtilsTest.cpp"
 )

--- a/scripts/lib/rrperf/problems.py
+++ b/scripts/lib/rrperf/problems.py
@@ -128,6 +128,9 @@ class GEMMSolution:
     storeLDS_D: bool = True
     betaInFma: bool = True
 
+    padLDS_A: int = -1
+    padLDS_B: int = -1
+
     direct2LDS_A: bool = False
     direct2LDS_B: bool = False
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -156,6 +156,7 @@ set(
     catch/TestKernels.cpp
 
     catch/AddDeallocateTest.cpp
+    catch/AddLDSPaddingTest.cpp
     catch/AddPrefetchTest.cpp
     catch/AliasDataFlowTagsTest.cpp
     catch/AnnotateInstructionsTest.cpp

--- a/test/catch/AddLDSPaddingTest.cpp
+++ b/test/catch/AddLDSPaddingTest.cpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2025 AMD ROCm(TM) Software
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <rocRoller/KernelGraph/KernelGraph.hpp>
+#include <rocRoller/KernelGraph/Transforms/AddLDSPadding.hpp>
+#include <rocRoller/KernelGraph/Transforms/AddLDSPadding_detail.hpp>
+
+namespace AddPrefetchTest
+{
+    using namespace rocRoller;
+    using namespace rocRoller::KernelGraph::CoordinateGraph;
+    using namespace rocRoller::KernelGraph::AddLDSPaddingDetail;
+
+    TEST_CASE("AddLDSPadding", "[kernel-graph][graph-transforms]")
+    {
+        // FP6 is handled as a special case
+        std::map<std::pair<DataType, LayoutType>, uint> expected
+            = {{{DataType::Float, LayoutType::MATRIX_A}, 1u},
+               {{DataType::Float, LayoutType::MATRIX_B}, 1u},
+               {{DataType::FP8, LayoutType::MATRIX_A}, 4u},
+               {{DataType::FP8, LayoutType::MATRIX_B}, 4u},
+               {{DataType::FP6, LayoutType::MATRIX_A}, 0u},
+               {{DataType::FP6, LayoutType::MATRIX_B}, 0u},
+               {{DataType::FP4, LayoutType::MATRIX_A}, 8u},
+               {{DataType::FP4, LayoutType::MATRIX_B}, 8u}};
+
+        auto dataType   = GENERATE(DataType::Float, DataType::FP8, DataType::FP6, DataType::FP4);
+        auto layoutType = GENERATE(LayoutType::MATRIX_A, LayoutType::MATRIX_B);
+
+        KernelGraph::KernelGraph graph;
+
+        LDSPaddingInfo info{0, // ldsTag
+                            0, // upstreamEdge
+                            0, // downstreamEdge
+                            {0, 0}, // upstreamTags
+                            {0, 0}, // downstreamTags
+                            dataType,
+                            layoutType};
+
+        auto padding = computeDefaultLDSPaddingElements(graph, info);
+        auto key     = std::make_pair(dataType, layoutType);
+
+        // Only CHECK when have an expected value
+        if(expected.contains(key))
+        {
+            CHECK(padding == expected[key]);
+        }
+    }
+}


### PR DESCRIPTION
*Original author: @maemmett*

# PR overview

For LWP100-1638.  Reduces LDS bank conflicts by adding *element* padding to LDS buffers.

Automatic element padding of LDS buffers is enabled *by default*.  This can be disabled in the client by passing `--padLDS_A=0 --padLDS_B=0`.  You can also pass an explicit number (`--padLDS_A=8`) if you want to experiment.  The default value is `-1`, which lets rocRoller compute a sane default padding value.

See the new helper `computeDefaultLDSPaddingElements` for defaults.  Note for FP6 it's 0.

The basic mechanism of how this is achieved is described at the top of `AddLDSPadding.cpp`.  It's interesting to note that this all done in the coordinate graph :)

Using `rocprofv3 --output-file test --pmc SQ_LDS_BANK_CONFLICT` we can see an impact on an FP4 kernel.

No padding: SQ_LDS_BANK_CONFLICT is 780288.
Default padding: SQ_LDS_BANK_CONFLICT is 354560.

Example command line is:

    rocprofv3 --output-file test --pmc SQ_LDS_BANK_CONFLICT -- bin/client/rocRoller_gemm --mac_m=256 --mac_n=256 --mac_k=128 --wave_m=32 --wave_n=32 --wave_k=64 --wave_b=1 --workgroup_size_x=128 --workgroup_size_y=2 --unroll_x=0 --unroll_y=0 --loadLDS_A=True --loadLDS_B=True --storeLDS_D=True --betaInFma=True --scheduler=Priority --prefetch=True --prefetchInFlight=2 --prefetchLDSFactor=2 --prefetchMixMemOps=False --scale_A=Separate --scale_B=Separate --scaleType_A=E8M0 --scaleType_B=E8M0 --scaleBlockSize=32 --loadLDSScale_A=True --loadLDSScale_B=True --type_A=fp4 --type_B=fp4 --type_C=half --type_D=half --type_acc=float --trans_A=T --trans_B=N --padLDS_A=-1 --padLDS_B=-1 generate validate --M 1024 --N 1024 --K 4096

More testing and data collection is required.  This may lead to tweaks in how the padding is done.  Need to experiment with direct-to-lds in particular.

## Testing

Added tests for the helper that computes default LDS padding. 

# Commit message

Automatically add element padding to LDS buffers.
